### PR TITLE
Set gem limitation to Ruby 1.9+

### DIFF
--- a/pghero.gemspec
+++ b/pghero.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  
+  spec.required_ruby_version = ">= 1.9"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This gem supports new hash format ( haven't looked any further ) so this makes the gemspec limited to Ruby 1.9+