### PR TITLE
Avoid `require "rake"` to reduce memory use

### DIFF
--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -2,7 +2,6 @@ require "pghero/version"
 require "active_record"
 require "pghero/database"
 require "pghero/engine" if defined?(Rails)
-require "pghero/tasks"
 
 # models
 require "pghero/connection"

--- a/lib/tasks/pghero.rake
+++ b/lib/tasks/pghero.rake
@@ -1,5 +1,3 @@
-require "rake"
-
 namespace :pghero do
   desc "capture query stats"
   task capture_query_stats: :environment do


### PR DESCRIPTION
Instead move tasks to `lib/tasks/pghero.rake` to make tasks available to Rails without requiring the rake library.

Before running `bundle exec derailed bundle:mem` provided the following profile because rake was required:

    pghero: 25.7148 MiB
      pghero/tasks: 25.3359 MiB
        rake: 25.3359 MiB
          ...

After moving tasks to `lib/tasks/pghero.rake` file:

    pghero: 0.3516 MiB