### PR TITLE
Mention the PgQuery dependency for suggested indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The missing dashboard for Postgres
 
 PgHero can be installed as a standalone app or a Rails engine.
 
+To have PgHero suggest indexes for your database, install [PgQuery](https://github.com/lfittl/pg_query) as well. 
+
 ### Standalone
 
 [Linux](guides/Linux.md) - Ubuntu, Debian, and more


### PR DESCRIPTION
I spent a long time trying to figure out why suggested indexes weren't showing up for me, until I actually went through the code and found that it depends on PgQuery. A quick note will help greatly.