### PR TITLE
Added filter for current_database() in query and kill methods

### DIFF
--- a/lib/pghero/methods/kill.rb
+++ b/lib/pghero/methods/kill.rb
@@ -19,6 +19,7 @@ module PgHero
           WHERE
             pid <> pg_backend_pid()
             AND query <> '<insufficient privilege>'
+            AND datname = current_database()
         SQL
         true
       end

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -17,6 +17,7 @@ module PgHero
             query <> '<insufficient privilege>'
             AND state <> 'idle'
             AND pid <> pg_backend_pid()
+            AND datname = current_database()
           ORDER BY
             query_start DESC
         SQL
@@ -39,6 +40,7 @@ module PgHero
             AND state <> 'idle'
             AND pid <> pg_backend_pid()
             AND now() - query_start > interval '#{long_running_query_sec.to_i} seconds'
+            AND datname = current_database()
           ORDER BY
             query_start DESC
         SQL
@@ -63,6 +65,7 @@ module PgHero
             pg_stat_activity.query <> '<insufficient privilege>'
             AND pg_locks.mode = 'ExclusiveLock'
             AND pg_stat_activity.pid <> pg_backend_pid()
+            AND pg_stat_activity.datname = current_database()
           ORDER BY
             pid,
             query_start


### PR DESCRIPTION
I believe I have addressed this issue with the following modification.

- added "AND datname = current_database()" to the WHERE clause for methods 

```
- PgHero.Methods.Kill.kill_all
- PgHero.Methods.Queries.running_queries
- PgHero.Methods.Queries.long_running_queries
- PgHero.Methods.Queries.locks
```

@ankane Can I assume from your comment that you would like the connection counts in the Overview display and Connections tab modified to differentiate between server connections and current_database connections? Something like "Healthy number of connections 3 (2 to current database)"?

