### PR TITLE
Lets pass query to explain as hidden field of form instead of query param. Query param has limitations for size.

### DIFF
--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -1,0 +1,35 @@
+module PgHero
+
+  module HomeHelper
+    def pghero_post_to(name, url, html_options)
+      html_options = html_options.stringify_keys
+      html_options['value'] = name
+      html_options['type'] = 'submit'
+
+      params = html_options.delete('params')
+
+      form_options = html_options.delete('form') || {}
+      form_options[:method] = 'post'
+      form_options[:action] = url
+      form_options[:class] = 'button_to'
+
+      # required for post html method
+      request_token_tag = token_tag(nil)
+
+      button = tag('input', html_options)
+
+      inner_tags = ''.freeze.html_safe.
+        safe_concat(request_token_tag).
+        safe_concat(button)
+
+      if params
+        params.each do |param_name, param_value|
+          inner_tags.safe_concat tag(:input, type: 'hidden', name: param_name, value: param_value)
+        end
+      end
+
+      content_tag('form', inner_tags, form_options)
+    end
+  end
+
+end

--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -1,34 +1,26 @@
 module PgHero
 
   module HomeHelper
-    def pghero_post_to(name, url, html_options)
-      html_options = html_options.stringify_keys
-      html_options['value'] = name
-      html_options['type'] = 'submit'
-
-      params = html_options.delete('params')
+    def pghero_post_to(name, url, html_options = {})
+      html_options.stringify_keys!
 
       form_options = html_options.delete('form') || {}
-      form_options[:method] = 'post'
-      form_options[:action] = url
-      form_options[:class] = 'button_to'
+      form_options['class'] = 'button_to'
+      params = html_options.delete('params')
 
-      # required for post html method
-      request_token_tag = token_tag(nil)
+      form_tag(url, form_options) do
+        tags = ''.freeze.html_safe
 
-      button = tag('input', html_options)
+        tags.safe_concat submit_tag(name, html_options)
 
-      inner_tags = ''.freeze.html_safe.
-        safe_concat(request_token_tag).
-        safe_concat(button)
-
-      if params
-        params.each do |param_name, param_value|
-          inner_tags.safe_concat tag(:input, type: 'hidden', name: param_name, value: param_value)
+        if params
+          params.each do |param_key, param_value|
+            tags.safe_concat hidden_field_tag(param_key, param_value)
+          end
         end
-      end
 
-      content_tag('form', inner_tags, form_options)
+        tags
+      end
     end
   end
 

--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -17,7 +17,7 @@
         <td><%= query["started_at"] ? "#{number_with_delimiter(((now - Time.parse(query["started_at"])) * 1000).round)} ms" : nil %></td>
         <td><%= query["source"] %></td>
         <td class="text-right">
-          <%= button_to "Explain", explain_path, form: {target: "_blank"}, params: {query: query["query"]}, class: "btn btn-info" %>
+          <%= pghero_post_to "Explain", explain_path, form: {target: "_blank"}, params: {query: query["query"]}, class: "btn btn-info" %>
           <%= button_to "Kill", kill_path(pid: query["pid"]), class: "btn btn-danger" %>
         </td>
       </tr>

--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -17,7 +17,7 @@
         <td><%= query["started_at"] ? "#{number_with_delimiter(((now - Time.parse(query["started_at"])) * 1000).round)} ms" : nil %></td>
         <td><%= query["source"] %></td>
         <td class="text-right">
-          <%= button_to "Explain", explain_path(query: query["query"]), form: {target: "_blank"}, class: "btn btn-info" %>
+          <%= button_to "Explain", explain_path, form: {target: "_blank"}, params: {query: query["query"]}, class: "btn btn-info" %>
           <%= button_to "Kill", kill_path(pid: query["pid"]), class: "btn btn-danger" %>
         </td>
       </tr>


### PR DESCRIPTION
Hello.

In case of having complex queries to explain it could paste the wrong query on render explain form because the query param has the limitations. It's better to make post with query as form param. 