### PR TITLE
Handle where clauses with nested OR

### DIFF
--- a/lib/pghero/methods/suggested_indexes.rb
+++ b/lib/pghero/methods/suggested_indexes.rb
@@ -274,6 +274,8 @@ module PgHero
         if tree["BOOLEXPR"]
           if tree["BOOLEXPR"]["boolop"] == 0
             tree["BOOLEXPR"]["args"].flat_map { |v| parse_where(v) }
+          else
+            raise "Not Implemented"
           end
         elsif tree["AEXPR AND"]
           left = parse_where(tree["AEXPR AND"]["lexpr"])

--- a/test/best_index_test.rb
+++ b/test/best_index_test.rb
@@ -130,6 +130,15 @@ class BestIndexTest < Minitest::Test
     assert_no_index "Unknown structure", "SELECT NOW()"
   end
 
+  def test_where_or
+    assert_no_index "Unknown structure", "SELECT FROM users WHERE login_attempts = 0 OR login_attempts = 1"
+  end
+
+  def test_where_nested_or
+    assert_no_index "Unknown structure", "SELECT FROM users WHERE city_id = 1 AND (login_attempts = 0 OR login_attempts = 1)"
+  end
+
+
   def test_multiple_tables
     assert_no_index "JOIN not supported yet", "SELECT * FROM users INNER JOIN cities ON cities.id = users.city_id"
   end


### PR DESCRIPTION
A slow query with a nested `OR` crashed my PgHero installation earlier today. Digging a little into the code, I see that PgHero skips queries with boolean operators other than `AND` but blows up when such operators are nested, as in [this test case][test].

This patch fixes this edge case.

[test]: https://github.com/hakanensari/pghero/blob/nested-or/test/best_index_test.rb#L137-L139