### PR TITLE
`query_stats_readable?` support for newer rails/pg/arel gem

### DIFF
--- a/app/views/pg_hero/home/_suggested_index.html.erb
+++ b/app/views/pg_hero/home/_suggested_index.html.erb
@@ -13,6 +13,6 @@ Row estimates
 <%= details[:row_estimates].to_a.map { |k, v| "- #{k}: #{v}" }.join("\n") %><% end %><% if details[:table_indexes] %>
 
 Existing indexes
-<% details[:table_indexes].sort_by { |i| [PgHero.truthy?(i["primary"]) ? 0 : 1, i["columns"]] }.each do |i3| %>- <%= i3["columns"].join(", ") %><% if i3["using"] != "btree" %> <%= i3["using"].to_s.upcase %><% end %><% if PgHero.truthy?(i3["primary"]) %> PRIMARY<% elsif PgHero.truthy(i3["unique"]) %> UNIQUE<% end %>
+<% details[:table_indexes].sort_by { |i| [PgHero.truthy?(i["primary"]) ? 0 : 1, i["columns"]] }.each do |i3| %>- <%= i3["columns"].join(", ") %><% if i3["using"] != "btree" %> <%= i3["using"].to_s.upcase %><% end %><% if PgHero.truthy?(i3["primary"]) %> PRIMARY<% elsif PgHero.truthy?(i3["unique"]) %> UNIQUE<% end %>
 <% end %><% end %></pre></code>
 </div>

--- a/app/views/pg_hero/home/_suggested_index.html.erb
+++ b/app/views/pg_hero/home/_suggested_index.html.erb
@@ -13,6 +13,6 @@ Row estimates
 <%= details[:row_estimates].to_a.map { |k, v| "- #{k}: #{v}" }.join("\n") %><% end %><% if details[:table_indexes] %>
 
 Existing indexes
-<% details[:table_indexes].sort_by { |i| [i["primary"] == "t" ? 0 : 1, i["columns"]] }.each do |i3| %>- <%= i3["columns"].join(", ") %><% if i3["using"] != "btree" %> <%= i3["using"].to_s.upcase %><% end %><% if i3["primary"] == "t" %> PRIMARY<% elsif i3["unique"] != "f" %> UNIQUE<% end %>
+<% details[:table_indexes].sort_by { |i| [PgHero.truthy?(i["primary"]) ? 0 : 1, i["columns"]] }.each do |i3| %>- <%= i3["columns"].join(", ") %><% if i3["using"] != "btree" %> <%= i3["using"].to_s.upcase %><% end %><% if PgHero.truthy?(i3["primary"]) %> PRIMARY<% elsif PgHero.truthy(i3["unique"]) %> UNIQUE<% end %>
 <% end %><% end %></pre></code>
 </div>

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -56,6 +56,10 @@ module PgHero
         value == true || value == 't'
       end
 
+      def falsey?(value)
+        value == false || value == 'f'
+      end
+
       private
 
       def friendly_value(setting, unit)
@@ -112,7 +116,6 @@ module PgHero
           part
         end
       end
-
     end
   end
 end

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -45,10 +45,15 @@ module PgHero
         ssl_used = nil
         connection_model.transaction do
           execute("CREATE EXTENSION IF NOT EXISTS sslinfo")
-          ssl_used = select_all("SELECT ssl_is_used()").first["ssl_is_used"] == "t"
+          ssl_used = truthy?(select_all("SELECT ssl_is_used()").first["ssl_is_used"])
           raise ActiveRecord::Rollback
         end
         ssl_used
+      end
+
+      # Handles Rails 4 ('t') and Rails 5 (true) values.
+      def truthy?(value)
+        value == true || value == 't'
       end
 
       private
@@ -107,6 +112,7 @@ module PgHero
           part
         end
       end
+
     end
   end
 end

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -140,8 +140,8 @@ module PgHero
         indexes = []
 
         indexes_by_table = self.indexes.group_by { |i| i["table"] }
-        indexes_by_table.values.flatten.select { |i| i["primary"] == "f" && i["unique"] == "f" && !i["indexprs"] && !i["indpred"] && i["valid"] == "t" }.each do |index|
-          covering_index = indexes_by_table[index["table"]].find { |i| index_covers?(i["columns"], index["columns"]) && i["using"] == index["using"] && i["name"] != index["name"] && i["valid"] == "t" }
+        indexes_by_table.values.flatten.select { |i| i["primary"] == "f" && i["unique"] == "f" && !i["indexprs"] && !i["indpred"] && truthy?(i["valid"]) }.each do |index|
+          covering_index = indexes_by_table[index["table"]].find { |i| index_covers?(i["columns"], index["columns"]) && i["using"] == index["using"] && i["name"] != index["name"] && truthy?(i["valid"]) }
           if covering_index
             indexes << {"unneeded_index" => index, "covering_index" => covering_index}
           end

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -140,7 +140,7 @@ module PgHero
         indexes = []
 
         indexes_by_table = self.indexes.group_by { |i| i["table"] }
-        indexes_by_table.values.flatten.select { |i| i["primary"] == "f" && i["unique"] == "f" && !i["indexprs"] && !i["indpred"] && truthy?(i["valid"]) }.each do |index|
+        indexes_by_table.values.flatten.select { |i| falsey?(i["primary"]) && falsey?(i["unique"]) && !i["indexprs"] && !i["indpred"] && truthy?(i["valid"]) }.each do |index|
           covering_index = indexes_by_table[index["table"]].find { |i| index_covers?(i["columns"], index["columns"]) && i["using"] == index["using"] && i["name"] != index["name"] && truthy?(i["valid"]) }
           if covering_index
             indexes << {"unneeded_index" => index, "covering_index" => covering_index}

--- a/lib/pghero/methods/kill.rb
+++ b/lib/pghero/methods/kill.rb
@@ -2,7 +2,7 @@ module PgHero
   module Methods
     module Kill
       def kill(pid)
-        execute("SELECT pg_terminate_backend(#{pid.to_i})").first["pg_terminate_backend"] == "t"
+        truthy? execute("SELECT pg_terminate_backend(#{pid.to_i})").first["pg_terminate_backend"]
       end
 
       def kill_long_running_queries

--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -121,7 +121,7 @@ module PgHero
       # http://stackoverflow.com/questions/20582500/how-to-check-if-a-table-exists-in-a-given-schema
       def historical_query_stats_enabled?
         # TODO use schema from config
-        stats_connection.select_all(squish <<-SQL
+        truthy? stats_connection.select_all(squish <<-SQL
           SELECT EXISTS (
             SELECT
               1
@@ -135,7 +135,7 @@ module PgHero
               AND c.relkind = 'r'
           )
         SQL
-        ).to_a.first["exists"] == "t"
+        ).to_a.first["exists"]
       end
 
       def stats_connection


### PR DESCRIPTION
Some gem in my stack has been updated so that `select_all` returns `true`,
while the `PgHero.query_stats_readable?` method [expects it to return the
string `'t'`](https://github.com/ankane/pghero/blob/master/lib/pghero/methods/query_stats.rb#L38)

Output before:

```
[1] pry(main)> PgHero.query_stats_enabled?
   (0.4ms)  SELECT COUNT(*) AS count FROM pg_extension WHERE extname = 'pg_stat_statements'
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> false
[2] pry(main)> PgHero.send :select_all, "SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')"
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> [{"has_table_privilege"=>true}]
```

Output after:

```
[1] pry(main)> PgHero.query_stats_enabled?
   (0.5ms)  SELECT COUNT(*) AS count FROM pg_extension WHERE extname = 'pg_stat_statements'
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> true
```

This is using Rails 5.0.0.1, PostgreSQL 9.5.3, pg gem 0.18.4, Arel 7.1.1, but
I'm not sure which is the actual culprit.