### PR TITLE
Using permit instead of slice for Rails 5 compatibility

### DIFF
--- a/app/views/pg_hero/home/system.html.erb
+++ b/app/views/pg_hero/home/system.html.erb
@@ -4,7 +4,7 @@
       <%= link_to name, system_path(options) %>
     <% end %>
   </p>
-  <% path_options = params.slice(:duration, :period) %>
+  <% path_options = params.permit(:duration, :period) %>
 
   <h1>CPU</h1>
   <div style="margin-bottom: 20px;"><%= line_chart cpu_usage_path(path_options), max: 100, colors: ["#5bc0de"] %></div>


### PR DESCRIPTION
Rails 5 complains on the system view of unsafe parameters, this fixes that issue.