### PR TITLE
Add configurable explain_statement_timeout_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ PgHero.with(:database2) { PgHero.running_queries }
 - Added support for Rails API
 - Added support for Amazon STS
 - Fixed replica check when `hot_standby = on` for primary
+- Added configurable explain_timeout_sec
 
 ## 1.6.4
 

--- a/guides/Heroku.md
+++ b/guides/Heroku.md
@@ -89,6 +89,11 @@ Minimum calls for slow queries
 heroku config:set PGHERO_SLOW_QUERY_CALLS=100 # default
 ```
 
+Statement Timeout for Explain
+```sh
+heroku config:set PGHERO_EXPLAIN_TIMEOUT_SEC=10 # default
+````
+
 Minimum connections for high connections warning
 
 ```sh

--- a/guides/Linux.md
+++ b/guides/Linux.md
@@ -242,6 +242,11 @@ Minimum calls for slow queries
 sudo pghero config:set PGHERO_SLOW_QUERY_CALLS=100 # default
 ```
 
+Statement Timeout for Explain
+```sh
+sudo pghero config:set PGHERO_EXPLAIN_TIMEOUT_SEC=10 # default
+````
+
 Minimum connections for high connections warning
 
 ```sh

--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -166,6 +166,11 @@ Minimum calls for slow queries
 PgHero.slow_query_calls = 100 # default
 ```
 
+Statement Timeout for Explain
+```ruby
+PgHero.explain_timeout_sec = 10 # default
+```
+
 Minimum connections for high connections warning
 
 ```ruby

--- a/lib/generators/pghero/templates/config.yml
+++ b/lib/generators/pghero/templates/config.yml
@@ -12,6 +12,9 @@ databases:
     # Minimum calls for slow queries
     # slow_query_calls: 100
 
+    # Statement Timeout for Explain
+    # explain_timeout_sec: 10
+
     # Minimum connections for high connections warning
     # total_connections_threshold: 100
 

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -32,11 +32,12 @@ module PgHero
 
   # settings
   class << self
-    attr_accessor :long_running_query_sec, :slow_query_ms, :slow_query_calls, :total_connections_threshold, :cache_hit_rate_threshold, :env, :show_migrations
+    attr_accessor :long_running_query_sec, :slow_query_ms, :slow_query_calls, :explain_timeout_sec, :total_connections_threshold, :cache_hit_rate_threshold, :env, :show_migrations
   end
   self.long_running_query_sec = (ENV["PGHERO_LONG_RUNNING_QUERY_SEC"] || 60).to_i
   self.slow_query_ms = (ENV["PGHERO_SLOW_QUERY_MS"] || 20).to_i
   self.slow_query_calls = (ENV["PGHERO_SLOW_QUERY_CALLS"] || 100).to_i
+  self.explain_timeout_sec = (ENV["PGHERO_EXPLAIN_TIMEOUT_SEC"] || 10).to_i
   self.total_connections_threshold = (ENV["PGHERO_TOTAL_CONNECTIONS_THRESHOLD"] || 100).to_i
   self.cache_hit_rate_threshold = 99
   self.env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -52,6 +52,10 @@ module PgHero
       (config["slow_query_calls"] || PgHero.config["slow_query_calls"] || PgHero.slow_query_calls).to_i
     end
 
+    def explain_timeout_sec
+      (config["explain_timeout_sec"] || PgHero.config["explain_timeout_sec"] || PgHero.explain_timeout_sec).to_i
+    end
+
     def long_running_query_sec
       (config["long_running_query_sec"] || PgHero.config["long_running_query_sec"] || PgHero.long_running_query_sec).to_i
     end

--- a/lib/pghero/methods/explain.rb
+++ b/lib/pghero/methods/explain.rb
@@ -6,7 +6,7 @@ module PgHero
         explanation = nil
 
         # use transaction for safety
-        with_transaction(statement_timeout: 10000, rollback: true) do
+        with_transaction(statement_timeout: (explain_timeout_sec * 1000), rollback: true) do
           if (sql.sub(/;\z/, "").include?(";") || sql.upcase.include?("COMMIT")) && !explain_safe?
             raise ActiveRecord::StatementInvalid, "Unsafe statement"
           end


### PR DESCRIPTION
I'm using pghero locally in development.  While I understand the need to protect the production environment from long-running queries,
it doesn't make much sense have long_running_query_sec default to 60 seconds and then not allow explains longer than 10 seconds.
So, I propose that we default the explain statement timeout to 10 seconds, but allow configuration for other values.