### PR TITLE
Add semi-colons for the extremely lazy among us.

### DIFF
--- a/guides/Docker.md
+++ b/guides/Docker.md
@@ -26,8 +26,8 @@ CREATE TABLE "pghero_query_stats" (
   "total_time" float,
   "calls" bigint,
   "captured_at" timestamp
-)
-CREATE INDEX ON "pghero_query_stats" ("database", "captured_at")
+);
+CREATE INDEX ON "pghero_query_stats" ("database", "captured_at");
 ```
 
 Schedule the task below to run every 5 minutes.
@@ -50,8 +50,8 @@ CREATE TABLE "pghero_space_stats" (
   "relation" text,
   "size" bigint,
   "captured_at" timestamp
-)
-CREATE INDEX ON "pghero_space_stats" ("database", "captured_at")
+);
+CREATE INDEX ON "pghero_space_stats" ("database", "captured_at");
 ```
 
 Schedule the task below to run once a day.


### PR DESCRIPTION
Adding the semi-colons means those code blocks can be copy, pasted, and run as-is in `psql`.  Otherwise you need to add the semi-colons manually ;)