### PR TITLE
fixed error for queries done by another user.

### DIFF
--- a/app/views/pg_hero/home/_queries_table.html.erb
+++ b/app/views/pg_hero/home/_queries_table.html.erb
@@ -23,6 +23,7 @@
       </tr>
     <% end %>
     <% queries.each do |query| %>
+
       <tr>
         <td>
           <%= number_with_delimiter(query[:total_minutes].round) %> min
@@ -51,7 +52,7 @@
               <% end %>
             <% end %>
             <% if @show_details %>
-              <%= link_to "details", show_query_path(query[:query_hash]), target: "_blank" %>
+              <%= link_to "details", show_query_path(query[:query_hash]), target: "_blank" unless query[:query] == "<insufficient privilege>" %>
             <% end %>
           </span>
         </td>

--- a/app/views/pg_hero/home/_queries_table.html.erb
+++ b/app/views/pg_hero/home/_queries_table.html.erb
@@ -23,7 +23,6 @@
       </tr>
     <% end %>
     <% queries.each do |query| %>
-
       <tr>
         <td>
           <%= number_with_delimiter(query[:total_minutes].round) %> min
@@ -51,7 +50,7 @@
                 &middot;
               <% end %>
             <% end %>
-            <% if @show_details %>
+            <% if @show_details && query[:query] != "<insufficient privilege>" %>
               <%= link_to "details", show_query_path(query[:query_hash]), target: "_blank" unless query[:query] == "<insufficient privilege>" %>
             <% end %>
           </span>


### PR DESCRIPTION
When queries are done on the schema by another user, the link_to did not check for the query type.  If the query indicates "insufficient privileges", the query_hash is not present and an error occurs.