### PR TITLE
Linux.md: Fix unclosed code block

### DIFF
--- a/guides/Linux.md
+++ b/guides/Linux.md
@@ -187,6 +187,7 @@ Schedule the task below to run once a day.
 
 ```sh
 sudo pghero run rake pghero:capture_space_stats
+```
 
 ## System Stats
 


### PR DESCRIPTION
There was an unclosed code block at the bottom of the "Historical Space
Stats" section that was running over into "System Stats".