### PR TITLE
Add information about temporary files used by PSQL.

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -93,6 +93,7 @@ module PgHero
       @show_migrations = PgHero.show_migrations
       @system_stats_enabled = @database.system_stats_enabled?
       @index_bloat = [] # @database.index_bloat
+      @temp_files_stats = @database.temp_files_stats
     end
 
     def relation_space

--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -81,3 +81,18 @@ remove_index <%= query[:table].to_sym.inspect %>, name: <%= query[:index].to_s.i
     </tbody>
   </table>
 </div>
+
+<div class="content">
+  <h2>Temporary files</h2>
+  <% if @temp_files_stats[:temp_files].zero? %>
+    <p>
+      Great news! Your database doesn't need to create temporary files to operate.
+    </p>
+  <% else %>
+    <p>
+      So far your database produced <%= @temp_files_stats[:temp_files] %> temporary files, in total size of <%= @temp_files_stats[:temp_bytes] %> bytes.
+      <br/>
+      You may want to review your queries or adjust <kbd>WORK_MEM</kbd> setting.
+    </p>
+  <% end %>
+</div>

--- a/lib/pghero/methods/space.rb
+++ b/lib/pghero/methods/space.rb
@@ -132,6 +132,15 @@ module PgHero
       def space_stats_enabled?
         table_exists?("pghero_space_stats")
       end
+
+      def temp_files_stats
+        query = <<-SQL
+          SELECT temp_files, temp_bytes
+          FROM pg_stat_database
+          WHERE datname = current_database()
+        SQL
+        select_all(query).first
+      end
     end
   end
 end


### PR DESCRIPTION
### Description
Sometimes there is need that Postgresql need to use some temp
files. For example for sorting. This is slower than normal in-memory
sorting and more I/O expensive.

### Motivation
Personally I have one issue with Rails app having troubles because of
slowing responding database caused by big I/O usage spike. Here is my
"post mortem" - https://mergujmyniktniewola.it/2017/10/04/postgresql-temporary-files.html.

### Screenshot
<img width="1552" alt="screen shot 2017-10-04 at 20 58 51" src="https://user-images.githubusercontent.com/6630/31194288-f7176940-a946-11e7-9d7b-aca054566762.png">
