### PR TITLE
Use :table_schema instead of public

### DIFF
--- a/lib/pghero/methods/sequences.rb
+++ b/lib/pghero/methods/sequences.rb
@@ -28,8 +28,7 @@ module PgHero
 
         # parse out sequence
         sequences.each do |column|
-          m = /^nextval\('(.+)'\:\:regclass\)$/.match(column.delete(:default_value))
-          column[:schema], column[:sequence] = unquote_ident(m[1])
+          column[:schema], column[:sequence] = unquote_ident(column)
           column[:max_value] = column[:column_type] == 'integer' ? 2147483647 : 9223372036854775807
         end
 
@@ -46,11 +45,13 @@ module PgHero
 
       private
 
-      def unquote_ident(value)
-        schema, seq = value.split(".")
+      def unquote_ident(column)
+        m = /^nextval\('(.+)'\:\:regclass\)$/.match(column.delete(:default_value))
+
+        schema, seq = m[1].split(".")
         unless seq
           seq = schema
-          schema = 'public'
+          schema = column[:table_schema]
         end
         [unquote(schema), unquote(seq)]
       end


### PR DESCRIPTION
My table schema is not `public`, thus I'm getting the following exception:

```
Started GET "/" for 172.19.0.1 at 2017-11-10 11:39:07 +0000
Processing by PgHero::HomeController#index as HTML
Completed 500 Internal Server Error in 40ms

ActiveRecord::StatementInvalid (PG::UndefinedTable: ERROR:  relation "public.actions_id_seq" does not exist
LINE 1: SELECT last_value FROM "public"."actions_id_seq" UNION ALL S...
                               ^
: SELECT last_value FROM "public"."actions_id_seq" UNION ALL SELECT last_value FROM "public"."pghero_query_stats_id_seq" UNION ALL SELECT last_value FROM "datagra"."pghero_query_stats_id_seq"):

.... skepped.. 
pghero (2.0.7) lib/pghero/methods/basic.rb:38:in `select_all'
pghero (2.0.7) lib/pghero/methods/sequences.rb:36:in `sequences'
pghero (2.0.7) lib/pghero/methods/sequences.rb:44:in `sequence_danger'
pghero (2.0.7controllers) pg_hero/home_controller.rb:40:in `index'
```

To fix the issue, I'm using table schema instead of public