### PR TITLE
Don't allow pg gem v 1.0.0  as it's not compatible with rails

### DIFF
--- a/pghero.gemspec
+++ b/pghero.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcpostgresql-adapter"
   else
-    spec.add_development_dependency "pg"
+    spec.add_development_dependency "pg", "< 1.0.0"
     spec.add_development_dependency "pg_query"
   end
 end


### PR DESCRIPTION
https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start

PG 1.0.0 is not yet compatible with rails, so the test suite fails since it's using rails.