### PR TITLE
Adding index bloat link to home page.

### DIFF
--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -45,6 +45,7 @@
             <% end %>
             <li class="<%= controller.action_name == "explain" ? "active" : "" %>"><%= link_to "Explain", explain_path %></li>
             <li class="<%= controller.action_name == "tune" ? "active" : "" %>"><%= link_to "Tune", tune_path %></li>
+            <li class="<%= controller.action_name == "index_bloat" ? "active" : "" %>"><%= link_to "Index Bloat", index_bloat_path %></li>
           </ul>
 
           <% if @databases.size > 1 %>


### PR DESCRIPTION
This is a really minor change. The index bloat page is really useful but, there is no link to it that I can find.

This change just adds it into the main nav menu so that you can get to it easily.