### PR TITLE
Fix too big query on huge sequences

### DIFF
--- a/lib/pghero/methods/sequences.rb
+++ b/lib/pghero/methods/sequences.rb
@@ -36,7 +36,7 @@ module PgHero
 
         add_sequence_attributes(sequences)
 
-        select_all(sequences.select { |s| s[:readable] }.map { |s| "SELECT last_value FROM #{quote_ident(s[:schema])}.#{quote_ident(s[:sequence])}" }.join(" UNION ALL ")).each_with_index do |row, i|
+        select_all(sequences.each_slice(1024) { |slice| slice.select { |s| s[:readable] }.map { |s| "SELECT last_value FROM #{quote_ident(s[:schema])}.#{quote_ident(s[:sequence])}" }.join(" UNION ALL ")}).each_with_index do |row, i|
           sequences[i][:last_value] = row[:last_value]
         end
 


### PR DESCRIPTION
Fix issue when we have many sequence and default max_stack_depth

ActiveRecord::StatementInvalid: PG::StatementTooComplex: ERROR: stack depth limit exceeded HINT: Increase the configuration parameter "max_stack_depth" (currently 2048kB), after ensuring the platform's stack depth limit is adequate.

Tested with 7k+ sequences