### PR TITLE
Add instructions for generating config.yml 

### DIFF
--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -14,6 +14,19 @@ mount PgHero::Engine, at: "pghero"
 
 Be sure to [secure the dashboard](#security) in production.
 
+## Configuration
+
+PgHero can be configured with a file: `config/pghero.yml`
+
+You can generate a skeleton of the file with:
+
+```sh
+rails generate pghero:config
+```
+
+If you only need the default settings and Rails database connection and credentials you don't need to
+create this file.
+
 ### Suggested Indexes
 
 PgHero can suggest indexes to add. To enable, add to your Gemfile:
@@ -132,7 +145,7 @@ This requires the following IAM policy:
 
 ## Multiple Databases
 
-Create `config/pghero.yml` with:
+Edit `config/pghero.yml` with eg:
 
 ```yml
 databases:


### PR DESCRIPTION
I was a bit confused as to where this file was when reading the documentation and it tool me a while to dig into the source to see that there was a generator for it that isn't referenced.

I think this change to the documentation might save some future users some time.