### PR TITLE
Optional statistics reset

### DIFF
--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -57,6 +57,8 @@ module PgHero
       end
 
       def reset_query_stats(raise_errors: false)
+        return true if config["reset_query_stats"] && config["reset_query_stats"] != true
+
         execute("SELECT pg_stat_statements_reset()")
         true
       rescue ActiveRecord::StatementInvalid => e


### PR DESCRIPTION
Hi :)

I don't have control over the database. It's set up to reset statistics every night and doesn't allow anyone else do it. So when I wanted to use the historical stats feature, it was failing.

This change will allow me to use historical query stats. I will set up the schedule according to db reset schedule and disable reset from PgHero and it will work. Am I right?

Perhaps this will be useful to others as well?