### PR TITLE
Use the last comment only as the origin

### DIFF
--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -143,7 +143,7 @@ module PgHero
               total_time / 1000 / 60 AS total_minutes,
               (total_time / calls) AS average_time,
               calls,
-              (SELECT regexp_matches(query, '/\\*(.+)\\*/'))[1] AS origin
+              (SELECT regexp_matches(query, '.*/\\*(.+?)\\*/'))[1] AS origin
             FROM
               pghero_query_stats
             WHERE


### PR DESCRIPTION
We have a query with multiple comments, plus marginalia, generating something like:

    SELECT a, b, c
      FROM some_table
      WHERE something = true
        /* meaningful comment */
        AND (some = meaningful AND query = clauses)
        /* another meaningful comment */
        AND (even = more AND query = clauses)
      ORDER BY nonsense
      LIMIT 100 /*line:/app/models/my/fantastic/model.rb:65:in `some_method'*/

At the moment this yields an origin of:

      meaningful comment */
        AND (some = meaningful AND query = clauses)
        /* another meaningful comment */
        AND (even = more AND query = clauses)
      ORDER BY nonsense
      LIMIT 100 /*line:/app/models/my/fantastic/model.rb:65:in `some_method'

Not super useful, and it can change based on the query's low-fi activerecord interpolated parameters, so they get grouped incorrectly.

Instead, this adjusts the regexp to capture a non-greedy part as close to the end of the string as possible and yields the intended origin:

    line:/app/models/my/fantastic/model.rb:65:in `some_method'

I tried using an `$` anchor but it didn't work as intended on the multi line string, as much as I tried using flags and switch RE engines. This version works, though.