### PR TITLE
Monospace explain input

### DIFF
--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -98,6 +98,7 @@ textarea {
   height: 120px;
   border: solid 1px #ddd;
   padding: 10px;
+  font-family: monospace;
 }
 
 hr {


### PR DESCRIPTION
I've always found it very frustrating to read and revise a query in the textarea on the explain page, especially after clicking through one of the (infinitely useful!) query details -> explain links, because of the variable width font. I wish the queries here looked the same as the rest of the app. Instead of this:

<img width="1046" alt="screen shot 2018-06-02 at 9 57 34 pm" src="https://user-images.githubusercontent.com/14028/40874391-07b3dc56-66b2-11e8-9337-4fc41337bd17.png">

I'd love to see this:

<img width="1049" alt="screen shot 2018-06-02 at 9 58 22 pm" src="https://user-images.githubusercontent.com/14028/40874392-0e02321a-66b2-11e8-90b5-807af0d52c08.png">

I've also included an extra commit, depending on your feelings, which autogrows the textarea, with sensbile minimum and maximum, so that the whole query (hopefully) becomes visible for an even better picture:

<img width="1050" alt="screen shot 2018-06-02 at 10 10 49 pm" src="https://user-images.githubusercontent.com/14028/40874401-266a7920-66b2-11e8-80e0-9d037135def4.png">

Thanks for making an amazing tool!