### PR TITLE
The queries slider goes back up to 30 days.

### DIFF
--- a/app/assets/javascripts/pghero/application.js
+++ b/app/assets/javascripts/pghero/application.js
@@ -11,37 +11,22 @@ function highlightQueries() {
 }
 
 function initSlider() {
-  function roundTime(time) {
-    var period = 1000 * 60 * 5;
-    return new Date(Math.ceil(time.getTime() / period) * period);
-  }
-
-  function pad(num) {
-    return (num < 10) ? "0" + num : num;
-  }
-
-  var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-
-  var days = 1;
-  var now = new Date();
-  var sliderStartAt = roundTime(now) - days * 24 * 60 * 60 * 1000;
-  var sliderMax = 24 * 12 * days;
-
-  startAt = startAt || sliderStartAt;
-  var min = (startAt > 0) ? (startAt - sliderStartAt) / (1000 * 60 * 5) : 0;
-
-  var max = (endAt > 0) ? (endAt - sliderStartAt) / (1000 * 60 * 5) : sliderMax;
+  var period = 1000 * 60 * 5; // 5 minutes
+  var latestTimestamp = new Date(latest).getTime();
+  var earliestTimestamp = new Date(earliest).getTime();
+  var startTimestamp = new Date(startAt).getTime();
+  var endTimestamp = new Date(endAt).getTime();
 
   var $slider = $("#slider");
 
   $slider.noUiSlider({
     range: {
-      min: 0,
-      max: sliderMax
+      min: earliestTimestamp,
+      max: latestTimestamp
     },
-    step: 1,
+    step: period,
     connect: true,
-    start: [min, max]
+    start: [startTimestamp, endTimestamp]
   });
 
   function updateText() {
@@ -50,23 +35,23 @@ function initSlider() {
     setText("#range-end", values[1]);
   }
 
-  function setText(selector, offset) {
-    var time = timeAt(offset);
+  function setText(selector, timestamp) {
+    var time = timeAt(timestamp)
 
     var html = "";
-    if (time == now) {
+    if (time == latest) {
       if (selector == "#range-end") {
         html = "Now";
       }
     } else {
-      html = months[time.getMonth()] + " " + time.getDate() + ", " + pad(time.getHours()) + ":" + pad(time.getMinutes());
+      html = time.toLocaleString();
     }
     $(selector).html(html);
   }
 
-  function timeAt(offset) {
-    var time = new Date(sliderStartAt + (offset * 5) * 60 * 1000);
-    return (time > now) ? now : time;
+  function timeAt(time) {
+    var time = new Date(Math.round(time));
+    return (time > latest) ? latest : time;
   }
 
   function timeParam(time) {
@@ -87,10 +72,8 @@ function initSlider() {
     var endAt = timeAt(values[1]);
 
     var params = {}
-    if (startAt.getTime() != sliderStartAt) {
-      params.start_at = timeParam(startAt);
-    }
-    if (endAt < now) {
+    params.start_at = timeParam(startAt);
+    if (endAt < latest) {
       params.end_at = timeParam(endAt);
     }
     if (sort) {

--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -120,7 +120,7 @@ module PgHero
       if @historical_query_stats_enabled
         begin
           # the earliest we have data for
-          @earliest = @database.earliest
+          @earliest = @database.earliest rescue 24.hours.ago
           @earliest = Time.at((@earliest.to_i / 5.minutes).floor * 5.minutes).utc # floor to 5 minutes
           @earliest = [@earliest, 30.days.ago].max # only go back 30 days max
 

--- a/app/views/pg_hero/home/_query_stats_slider.html.erb
+++ b/app/views/pg_hero/home/_query_stats_slider.html.erb
@@ -9,7 +9,9 @@
   var minAverageTime = <%= @min_average_time.to_json %>;
   var minCalls = <%= @min_calls.to_json %>;
   var debug = <%= @debug.to_json %>;
-  var startAt = <%= params[:start_at] ? @start_at.to_i * 1000 : "null" %>;
+  var earliest = <%= @earliest.to_i %> * 1000;
+  var latest = <%= @latest.to_i %> * 1000;
+  var startAt = <%= @start_at.to_i %> * 1000;
   var endAt = <%= @end_at.to_i %> * 1000;
 
   initSlider();

--- a/app/views/pg_hero/home/queries.html.erb
+++ b/app/views/pg_hero/home/queries.html.erb
@@ -18,7 +18,7 @@
 
   <% if @query_stats_enabled %>
     <% if @error %>
-      <div class="alert alert-danger">Cannot understand start or end time.</div>
+      <div class="alert alert-danger"><%= @error %></div>
     <% elsif @query_stats.any? || @historical_query_stats_enabled %>
       <%= render partial: "queries_table", locals: {queries: @query_stats, sort_headers: true} %>
       <script>

--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -30,6 +30,10 @@ module PgHero
         select_one("SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = 'pg_stat_statements'") > 0
       end
 
+      def earliest
+        select_one("SELECT min(captured_at) FROM pghero_query_stats")
+      end
+
       # only cache if true
       def query_stats_enabled?
         @query_stats_enabled ||= query_stats_readable?


### PR DESCRIPTION
I made this change for our purposes, you're welcome to merge it if you think it's useful.

Still defaults to showing 24 hours but you can slide back.
If there is less than 30 days of data, then go back far enough.
Tidied up some of the slider code to let the component handle the
scaling.

Some tangential changes are:
- It's hard to make small adjustments when the slider represents 30x more time.
- The time format changed to just the default javascript locale specific date time format.
- include the exception message if there was one when sorting out times on the server.

![slider](https://user-images.githubusercontent.com/45890/42020454-86f37052-7aea-11e8-9f76-ddd065b03ae3.png)

Thanks for pghero!