### PR TITLE
display columns with remove_index migration

### DIFF
--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -15,5 +15,16 @@ module PgHero
     def pghero_js_var(name, value)
       "var #{name} = #{json_escape(value.to_json(root: false))};".html_safe
     end
+
+    def pghero_remove_index(query)
+      if query[:columns]
+        columns = query[:columns].map(&:to_sym)
+        columns = columns.first if columns.size == 1
+      end
+      ret = "remove_index #{ query[:table].to_sym.inspect },"
+      ret << " name: #{ (query[:name] || query[:index]).to_s.inspect }"
+      ret << ", column: #{ columns.inspect}" if columns
+      ret
+    end
   end
 end

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -387,7 +387,7 @@
       <pre>rails generate migration remove_unneeded_indexes</pre>
       <p>And paste</p>
       <pre style="overflow: scroll; white-space: pre; word-break: normal;"><% @duplicate_indexes.each do |query| %>
-remove_index <%= query[:unneeded_index][:table].to_sym.inspect %>, name: <%= query[:unneeded_index][:name].to_s.inspect %><% end %></pre>
+<%= pghero_remove_index(query[:unneeded_index]) %><% end %></pre>
     </div>
 
     <table class="table duplicate-indexes">
@@ -491,7 +491,7 @@ pg_stat_statements.track = all</pre>
       <pre>rails generate migration remove_unused_indexes</pre>
       <p>And paste</p>
       <pre style="overflow: scroll; white-space: pre; word-break: normal;"><% @unused_indexes.each do |query| %>
-remove_index <%= query[:table].to_sym.inspect %>, name: <%= query[:index].to_s.inspect %><% end %></pre>
+<%= pghero_remove_index(query)%><% end %></pre>
     </div>
 
     <table class="table">

--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -33,7 +33,7 @@
       <pre>rails generate migration remove_unused_indexes</pre>
       <p>And paste</p>
       <pre style="overflow: scroll; white-space: pre; word-break: normal;"><% @unused_indexes.sort_by { |q| [-q[:size_bytes], q[:index]] }.each do |query| %>
-remove_index <%= query[:table].to_sym.inspect %>, name: <%= query[:index].to_s.inspect %><% end %></pre>
+<%= pghero_remove_index(query) %><% end %></pre>
     </div>
   <% end %>
 


### PR DESCRIPTION
On our team, we want migrations to be reversible. So I needed to add the columns to the `remove_index` clause.

I put the text into a helper clause.
Turns out there was a bug in the helper, so I added a `helper :base` clause to fix that.

Hope this works for you.

re formatting:
- I can pull the fix for helpers into a separate PR. so you can fix that bug before tackling this.
- I can put the `remove_index` into a single line.

Thanks
Keenan

---

before:

```ruby
remove_index :cloud_subnets_network_ports, name: "index_cloud_subnets_network_ports_on_cloud_subnet_id"
remove_index :configuration_profiles_configuration_tags, name: "index_direct_configuration_profiles_tags_profile_id"
remove_index :configuration_profiles_configuration_tags, name: "index_direct_configuration_profiles_tags_tag_id"
remove_index :load_balancer_health_check_members, name: "members_load_balancer_health_check_index"
remove_index :load_balancer_listener_pools, name: "index_load_balancer_listener_pools_on_load_balancer_listener_id"
remove_index :load_balancer_pool_member_pools, name: "load_balancer_pool_index"
```

after:

```ruby
remove_index :cloud_subnets_network_ports,
              columns: :cloud_subnet_id,
              name: "index_cloud_subnets_network_ports_on_cloud_subnet_id"
remove_index :configuration_profiles_configuration_tags,
              columns: :configuration_profile_id,
              name: "index_direct_configuration_profiles_tags_profile_id"
remove_index :configuration_profiles_configuration_tags,
              columns: :configuration_tag_id,
              name: "index_direct_configuration_profiles_tags_tag_id"
remove_index :load_balancer_health_check_members,
              columns: :load_balancer_health_check_id,
              name: "members_load_balancer_health_check_index"
remove_index :load_balancer_listener_pools,
              columns: :load_balancer_listener_id,
              name: "index_load_balancer_listener_pools_on_load_balancer_listener_id"
remove_index :load_balancer_pool_member_pools,
              columns: :load_balancer_pool_id,
              name: "load_balancer_pool_index"
```

The `unused` (on index and space pages) are not currently affected. Adding in `:columns` hash would fix those too. Didn't know if you wanted this or where exactly that would go.