### PR TITLE
Disable script-src CSP in controller

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -6,6 +6,12 @@ module PgHero
 
     http_basic_authenticate_with name: ENV["PGHERO_USERNAME"], password: ENV["PGHERO_PASSWORD"] if ENV["PGHERO_PASSWORD"]
 
+    if respond_to?(:content_security_policy)
+      content_security_policy do |p|
+        p.script_src false
+      end
+    end
+
     if respond_to?(:before_action)
       before_action :check_api
       before_action :set_database


### PR DESCRIPTION
When Content Security Policy rules are defined in Rails, they usually do not allow inline scripts (`:unsafe_inline`). PGHero uses inline scripts to mount diagrams on the connections page (and possibly others).