### PR TITLE
[enhancement] add UI for blocked and blocking queries

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -33,6 +33,8 @@ module PgHero
 
       @autovacuum_queries, @long_running_queries = @database.long_running_queries.partition { |q| q[:query].starts_with?("autovacuum:") }
 
+      @blocked_queries = @database.blocked_queries
+
       connection_states = @database.connection_states
       @total_connections = connection_states.values.sum
       @idle_connections = connection_states["idle in transaction"].to_i
@@ -117,6 +119,11 @@ module PgHero
       if params[:state]
         @running_queries.select! { |q| q[:state] == params[:state] }
       end
+    end
+
+    def blocked_queries
+      @title = "Block Queries"
+      @blocked_queries = @database.blocked_queries
     end
 
     def queries

--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -122,7 +122,7 @@ module PgHero
     end
 
     def blocked_queries
-      @title = "Block Queries"
+      @title = "Blocked Queries"
       @blocked_queries = @database.blocked_queries
     end
 

--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -40,6 +40,7 @@
             <li class="<%= controller.action_name == "space" ? "active" : "" %>"><%= link_to "Space", space_path %></li>
             <li class="<%= controller.action_name == "connections" ? "active" : "" %>"><%= link_to "Connections", connections_path %></li>
             <li class="<%= controller.action_name == "live_queries" ? "active" : "" %>"><%= link_to "Live Queries", live_queries_path %></li>
+            <li class="<%= controller.action_name == "blocked_queries" ? "active" : "" %>"><%= link_to "Blocked Queries", blocked_queries_path %></li>
             <% unless @database.replica? %>
               <li class="<%= controller.action_name == "maintenance" ? "active" : "" %>"><%= link_to "Maintenance", maintenance_path %></li>
             <% end %>

--- a/app/views/pg_hero/home/_blocked_queries_table.html.erb
+++ b/app/views/pg_hero/home/_blocked_queries_table.html.erb
@@ -1,0 +1,61 @@
+<% queries.reverse.each_with_index do |query, i| %>
+  <h2>Query <%= i+1 %></h2>
+  <table class="table queries">
+    <thead>
+      <tr>
+        <th style="width: 20%;">Blocked pid</th>
+        <th style="width: 20%;">Blocked duration</th>
+        <th style="width: 20%;">Blocked mode</th>
+        <th style="width: 20%;">Locked item</th>
+        <th style="width: 20%;">Blocked user</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><%= query[:blocked_pid] %></td>
+          <td><%= number_with_delimiter(query[:blocked_duration_ms].round) %> ms</td>
+          <td><%= query[:blocked_mode] %></td>
+          <td><%= query[:locked_item] %></td>
+          <td><%= query[:blocked_user] %></td>
+        </tr>
+        <tr>
+          <td colspan="5" style="border-top: none; padding: 0;">
+          Blocked query:
+          <pre style="margin-top: 1em;"><code><%= query[:blocked_query] %></code></pre>
+          </td>
+        </tr>
+    </tbody>
+  </table>
+  <table class="table queries">
+    <thead>
+      <tr>
+        <th style="width: 20%;">Blocking pid</th>
+        <th style="width: 20%;">Blocking duration</th>
+        <th style="width: 20%;">Blocking mode</th>
+        <th style="width: 20%;">State of blocking process</th>
+        <th style="width: 20%;">Blocked user</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><%= query[:blocking_pid] %></td>
+          <td><%= number_with_delimiter(query[:blocking_duration_ms].round) %> ms</td>
+          <td><%= query[:blocking_mode] %></td>
+          <td><%= query[:state_of_blocking_process] %></td>
+          <td><%= query[:blocked_user] %></td>
+        </tr>
+        <tr>
+          <td colspan="8" style="border-top: none; padding: 0;">
+          Current or recent query in blocking process:
+          <pre style="margin-top: 1em;"><code><%= query[:current_or_recent_query_in_blocking_process] %></code></pre>
+          </td>
+        </tr>
+    </tbody>
+  </table>
+  <hr>
+<% end %>
+
+
+<script>
+  highlightQueries();
+</script>

--- a/app/views/pg_hero/home/_blocked_queries_table.html.erb
+++ b/app/views/pg_hero/home/_blocked_queries_table.html.erb
@@ -1,5 +1,5 @@
 <% queries.reverse.each_with_index do |query, i| %>
-  <h2>Query <%= i+1 %></h2>
+  <h2>Lock <%= i+1 %></h2>
   <table class="table queries">
     <thead>
       <tr>

--- a/app/views/pg_hero/home/blocked_queries.html.erb
+++ b/app/views/pg_hero/home/blocked_queries.html.erb
@@ -1,0 +1,7 @@
+<div class="content">
+  <h1>Blocked queries</h1>
+
+  <p><%= pluralize(@blocked_queries.size, "query") %></p>
+
+  <%= render partial: "blocked_queries_table", locals: {queries: @blocked_queries} %>
+</div>

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -27,6 +27,13 @@
       <span class="tiny"><%= @autovacuum_queries.size %> autovacuum</span>
     <% end %>
   </div>
+  <div class="alert alert-<%= @blocked_queries.empty? ? "success" : "warning" %>">
+    <% if @blocked_queries.any? %>
+      <%= pluralize(@blocked_queries.size, "blocked query") %>
+    <% else %>
+      No blocked queries
+    <% end %>
+  </div>
   <% if @extended %>
     <div class="alert alert-<%= @good_cache_rate ? "success" : "warning" %>">
       <% if @good_cache_rate %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ PgHero::Engine.routes.draw do
     get "space/:relation", to: "home#relation_space", as: :relation_space
     get "index_bloat", to: "home#index_bloat"
     get "live_queries", to: "home#live_queries"
+    get "blocked_queries", to: "home#blocked_queries"
     get "queries", to: "home#queries"
     get "queries/:query_hash", to: "home#show_query", as: :show_query
     get "system", to: "home#system"

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -40,12 +40,14 @@ module PgHero
             blockeda.usename AS blocked_user,
             blockeda.query as blocked_query,
             age(now(), blockeda.query_start) AS blocked_duration,
+            EXTRACT(EPOCH FROM NOW() - blockeda.query_start) * 1000.0 AS blocked_duration_ms,
             blockedl.mode as blocked_mode,
             blockinga.pid AS blocking_pid,
             blockinga.usename AS blocking_user,
             blockinga.state AS state_of_blocking_process,
             blockinga.query AS current_or_recent_query_in_blocking_process,
             age(now(), blockinga.query_start) AS blocking_duration,
+            EXTRACT(EPOCH FROM NOW() - blockinga.query_start) * 1000.0 AS blocking_duration_ms,
             blockingl.mode as blocking_mode
           FROM
             pg_catalog.pg_locks blockedl


### PR DESCRIPTION
### Feature
Add a new tab that shows blocked and blocking queries.
Related issue: https://github.com/ankane/pghero/issues/183

### Screenshot
Alert on index page:
<img width="929" alt="screen shot 2018-10-31 at 3 58 08 pm" src="https://user-images.githubusercontent.com/3990811/47834485-e3993b00-dd5c-11e8-968c-eb16ca0cf788.png">
The new tab:
<img width="909" alt="screen shot 2018-11-01 at 12 25 47 pm" src="https://user-images.githubusercontent.com/3990811/47874822-1af5ff00-ddd2-11e8-9ec6-50e4a36f7816.png">


