### PR TITLE
Allow custom config path with PGHERO_CONFIG_PATH new env variable

### DIFF
--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -42,7 +42,7 @@ module PgHero
   self.cache_hit_rate_threshold = 99
   self.env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
   self.show_migrations = true
-  self.config_path = "config/pghero.yml"
+  self.config_path = ENV["PGHERO_CONFIG_PATH"] || "config/pghero.yml"
 
   class << self
     extend Forwardable


### PR DESCRIPTION
Having the hardcoded value is no good, besides that, it creates some
limitation when trying to run pghero on specific environemnts such as
Kubernetes.

By running pghero on Kubernetes, where the config file is usually comming
from a config-map resource, it's required to mount a volume. Which, if
mounted on the same folder as the expected config file, overrides the
existing folder, deleting the file-system refereces of everthing else on
that folder, e.g.: puma.rb

Example error:
```ruby
/usr/local/bundle/gems/puma-3.12.0/lib/puma/dsl.rb:41:in `read': No such file or directory @ rb_sysopen - config/puma.rb (Errno::ENOENT)
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/dsl.rb:41:in `_load_from'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/configuration.rb:192:in `block in load'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/configuration.rb:192:in `each'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/configuration.rb:192:in `load'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/launcher.rb:59:in `initialize'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/cli.rb:69:in `new'
from /usr/local/bundle/gems/puma-3.12.0/lib/puma/cli.rb:69:in `initialize'
from /usr/local/bundle/gems/puma-3.12.0/bin/puma:8:in `new'
from /usr/local/bundle/gems/puma-3.12.0/bin/puma:8:in `<top (required)>'
from /usr/local/bundle/bin/puma:23:in `load'
from /usr/local/bundle/bin/puma:23:in `<main>'
```
Nevertheless, it's important to highlight this change doens't break
compatibility with previous versions.