### PR TITLE
[Idea] Display source addr port

### DIFF
--- a/app/views/pg_hero/home/_connections_table.html.erb
+++ b/app/views/pg_hero/home/_connections_table.html.erb
@@ -8,7 +8,7 @@
   <tbody>
     <% connection_sources.each do |source| %>
       <tr>
-        <td><%= source[:source] %> <div class="text-muted"><%= [source[:user], source[:database], source[:ip]].compact.join(" - ") %></div></td>
+        <td><%= source[:source] %> <div class="text-muted"><%= [source[:user], source[:database], "#{source[:ip]}:#{source[:port]}"].compact.join(" - ") %></div></td>
         <td><%= number_with_delimiter(source[:total_connections]) %></td>
       </tr>
     <% end %>

--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -27,7 +27,7 @@
       </tr>
       <tr>
         <td colspan="6" style="border-top: none; padding: 0;">
-          <%= query[:source] %> <span class="text-muted"><%= query[:user] %></span>
+          <%= query[:source] %> <span class="text-muted"><%= query[:user] %></span> <%= "#{query[:source_addr]}:#{query[:source_port]}" %>
           <pre style="margin-top: 1em;"><code><%= query[:query] %></code></pre>
         </td>
       </tr>

--- a/lib/pghero/methods/connections.rb
+++ b/lib/pghero/methods/connections.rb
@@ -28,13 +28,14 @@ module PgHero
             usename AS user,
             application_name AS source,
             client_addr AS ip,
+            client_port AS port,
             COUNT(*) AS total_connections
           FROM
             pg_stat_activity
           GROUP BY
-            1, 2, 3, 4
+            1, 2, 3, 4, 5
           ORDER BY
-            5 DESC, 1, 2, 3, 4
+            total_connections DESC, 1, 2, 3, 4, 5
         SQL
       end
     end

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -7,6 +7,8 @@ module PgHero
             pid,
             state,
             application_name AS source,
+            client_addr AS source_addr,
+            client_port AS source_port,
             age(NOW(), COALESCE(query_start, xact_start)) AS duration,
             #{server_version_num >= 90600 ? "(wait_event IS NOT NULL) AS waiting" : "waiting"},
             query,

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -39,4 +39,8 @@ class BasicTest < Minitest::Test
   def test_databases
     assert PgHero.databases[:primary].running_queries
   end
+
+  def test_connection_states
+    assert PgHero.databases[:primary].connection_sources
+  end
 end


### PR DESCRIPTION
I often need the port as I have many processes with the same name connecting to postgres.
Here I've added it to the connections and the live queries pages.