### PR TITLE
rename BaseHelper to resolve undefined method when include_all_helpers = false

### DIFF
--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -1,5 +1,5 @@
 module PgHero
-  module BaseHelper
+  module HomeHelper
     def pghero_pretty_ident(table, schema: nil)
       ident = table
       if schema && schema != "public"


### PR DESCRIPTION
Fixes #268 

I was able to resolve this issue in our local installation using the fix below.

Also, I think this should work for just about all versions of Rails.

I did not add tests because I didn't see any for the UI and this was a minimal change, but I'd love a sanity check.