### PR TITLE
Add clean_space_stats information to Rails guide

### DIFF
--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -109,6 +109,18 @@ Or with a scheduler like Clockwork, use:
 PgHero.capture_space_stats
 ```
 
+The space stats table can grow large over time. Remove old stats with:
+
+```sh
+rake pghero:clean_space_stats
+```
+
+or:
+
+```rb
+PgHero.clean_space_stats
+```
+
 ## System Stats
 
 CPU usage, IOPS, and other stats are available for Amazon RDS. Add these lines to your application’s Gemfile:


### PR DESCRIPTION
Documentation makes no mention to cleaning up space statistics, whereas it does for cleaning query statistics. This change will make the documentation consistent.