### PR TITLE
Add data protection to live queries.

### DIFF
--- a/lib/generators/pghero/templates/config.yml.tt
+++ b/lib/generators/pghero/templates/config.yml.tt
@@ -37,3 +37,6 @@ databases:
 # aws_access_key_id: ...
 # aws_secret_access_key: ...
 # aws_region: us-east-1
+
+# Data Protection. Normalize queries and replaces bind values with numeric variables.
+# data_protection: true

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -6,6 +6,7 @@ require "forwardable"
 require "pghero/methods/basic"
 require "pghero/methods/connections"
 require "pghero/methods/constraints"
+require "pghero/methods/data_protection"
 require "pghero/methods/explain"
 require "pghero/methods/indexes"
 require "pghero/methods/kill"
@@ -36,7 +37,7 @@ module PgHero
 
   # settings
   class << self
-    attr_accessor :long_running_query_sec, :slow_query_ms, :slow_query_calls, :explain_timeout_sec, :total_connections_threshold, :cache_hit_rate_threshold, :env, :show_migrations, :config_path
+    attr_accessor :long_running_query_sec, :slow_query_ms, :slow_query_calls, :explain_timeout_sec, :total_connections_threshold, :cache_hit_rate_threshold, :env, :show_migrations, :config_path, :data_protection
   end
   self.long_running_query_sec = (ENV["PGHERO_LONG_RUNNING_QUERY_SEC"] || 60).to_i
   self.slow_query_ms = (ENV["PGHERO_SLOW_QUERY_MS"] || 20).to_i
@@ -47,6 +48,7 @@ module PgHero
   self.env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
   self.show_migrations = true
   self.config_path = ENV["PGHERO_CONFIG_PATH"] || "config/pghero.yml"
+  self.data_protection = ENV["PGHERO_DATA_PROTECTION"] || false
 
   class << self
     extend Forwardable

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -3,6 +3,7 @@ module PgHero
     include Methods::Basic
     include Methods::Connections
     include Methods::Constraints
+    include Methods::DataProtection
     include Methods::Explain
     include Methods::Indexes
     include Methods::Kill
@@ -75,6 +76,10 @@ module PgHero
 
     def aws_db_instance_identifier
       @db_instance_identifier ||= config["aws_db_instance_identifier"] || config["db_instance_identifier"]
+    end
+
+    def data_protection
+      config["data_protection"] || PgHero.config["data_protection"] || PgHero.data_protection
     end
 
     # TODO remove in next major version

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -63,6 +63,14 @@ module PgHero
         result
       end
 
+      def select_all_with_data_protection(sql, conn = nil)
+        result = select_all(sql, conn)
+        result.each do |row|
+          row[:query] = anonymize_query(row[:query])
+        end
+        result
+      end
+
       def select_one(sql, conn = nil)
         select_all(sql, conn).first.values.first
       end

--- a/lib/pghero/methods/data_protection.rb
+++ b/lib/pghero/methods/data_protection.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PgHero
+  module Methods
+    module DataProtection
+      def anonymize_query(query)
+        if data_protection
+          raise(Error, "PgQuery not loaded") unless defined?(PgQuery)
+
+          PgQuery.normalize(query)
+        else
+          query
+        end
+      end
+    end
+  end
+end

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -2,7 +2,7 @@ module PgHero
   module Methods
     module Queries
       def running_queries(min_duration: nil, all: false)
-        select_all <<-SQL
+        select_all_with_data_protection <<-SQL
           SELECT
             pid,
             state,
@@ -33,7 +33,7 @@ module PgHero
       # from https://wiki.postgresql.org/wiki/Lock_Monitoring
       # and https://big-elephants.com/2013-09/exploring-query-locks-in-postgres/
       def blocked_queries
-        select_all <<-SQL
+        select_all_with_data_protection <<-SQL
           SELECT
             COALESCE(blockingl.relation::regclass::text,blockingl.locktype) as locked_item,
             blockeda.pid AS blocked_pid,


### PR DESCRIPTION
Hey Andrew,

I'm proposing an update to PgHero to protect live queires from possibly exposing sensite data.
The motivation for this is to avoid exposing data to the users that have access to PgHero.

The implementation adds a optional config `data_protection: true` and uses `PgQuery.normalize(query)` to replace query params with numbered parameters.

Let me know your thought on this.
