### PR TITLE
Added Percentage of dead tuples in maintenance tab

### DIFF
--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -7,6 +7,7 @@
         <th>Table</th>
         <th style="width: 20%;">Last Vacuum</th>
         <th style="width: 20%;">Last Analyze</th>
+        <th style="width: 20%;">Dead Rows</th>
       </tr>
     </thead>
     <tbody>
@@ -30,6 +31,13 @@
             <% time = [table[:last_autoanalyze], table[:last_analyze]].compact.max %>
             <% if time %>
               <%= time.in_time_zone(@time_zone).strftime("%-m/%-e %l:%M %P") %>
+            <% else %>
+              <span class="text-muted">Unknown</span>
+            <% end %>
+          </td>
+          <td>
+            <% if table[:n_live_tup] != 0 %>
+              <%= (table[:n_dead_tup] * 100 / table[:n_live_tup]) %> %
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>

--- a/lib/pghero/methods/maintenance.rb
+++ b/lib/pghero/methods/maintenance.rb
@@ -57,7 +57,9 @@ module PgHero
             last_vacuum,
             last_autovacuum,
             last_analyze,
-            last_autoanalyze
+            last_autoanalyze,
+            n_dead_tup,
+            n_live_tup
           FROM
             pg_stat_user_tables
           ORDER BY


### PR DESCRIPTION
Fixes: https://github.com/ankane/pghero/issues/227

Added a column in the maintenance tab to show the percentage of dead rows in tables. This can be useful in the following scenario:

- To make sure that no table is bloated to an unacceptable level
- To figure out if any table requires more aggressive vacuum than configured

Screenshot:
<img width="424" alt="Screenshot 2019-12-10 at 9 09 36 AM" src="https://user-images.githubusercontent.com/9051383/70493525-fbc9b500-1b2d-11ea-83c3-19a11e11d3ae.png">

