### PR TITLE
remove duplicate sequences

### DIFF
--- a/lib/pghero/methods/sequences.rb
+++ b/lib/pghero/methods/sequences.rb
@@ -37,6 +37,7 @@ module PgHero
           column.delete(:default_value) if column[:sequence]
         end
 
+        sequences = sequences.uniq { |s| [s[:schema], s[:sequence]] }
         add_sequence_attributes(sequences)
 
         sequences.select { |s| s[:readable] }.each_slice(1024) do |slice|


### PR DESCRIPTION
Sometimes multiple tables use the same unique id sequence.
This typically happens when table inheritance is used


For our database, it reduced the sequences from 330 to 292 (12%).
But in the grand scheme of things, this is such an edge case and a few extra rows is not the end of the world.

Anyway, merge or close - up to you.

Thanks again for the great project