### PR TITLE
Remove README reference to PgHero.locks

### DIFF
--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -174,7 +174,6 @@ PgHero.relation_sizes
 PgHero.index_hit_rate
 PgHero.table_hit_rate
 PgHero.total_connections
-PgHero.locks
 ```
 
 Kill queries


### PR DESCRIPTION
The method was deleted in https://github.com/ankane/pghero/commit/056f814318897297ada96