### PR TITLE
Improved Index Suggestions

### DIFF
--- a/app/views/pg_hero/home/_suggested_index.html.erb
+++ b/app/views/pg_hero/home/_suggested_index.html.erb
@@ -2,7 +2,7 @@
   <% unless @debug %>
     <div style="float: right; color: #f0ad4e; margin-top: 0px; padding: 10px; cursor: pointer;" onclick="document.getElementById('details-<%= index.object_id %>').style.display = 'block'; this.style.display = 'none';">Details</div>
   <% end %>
-  <code><pre style="color: #eee; background-color: #333;">CREATE INDEX CONCURRENTLY ON <%= index[:table] %><% if index[:using] %> USING <%= index[:using] %><% end %> (<%= index[:columns].join(", ") %>)</pre></code>
+  <code><pre style="color: #eee; background-color: #333;">CREATE INDEX CONCURRENTLY ON <%= index[:table] %><% if index[:using] %> USING <%= index[:using] %><% end %> (<%= index[:columns].zip(Array(index[:opclasses])).map { |x| x.compact.join(' ') }.join(", ") %>)</pre></code>
 <% end %>
 <div id="details-<%= index.object_id %>" style="<%= "display: none;" unless @debug %>">
   <code><pre style="color: #f0ad4e; background-color: #333;"><% if details[:explanation] %><%= details[:explanation] %>

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -367,9 +367,14 @@ module PgHero
       end
 
       # REF https://www.postgresql.org/docs/13/indexes-multicolumn.html
-      def index_covers?(desired_index, column_info)
-        # indexed_columns.first(columns.size) == columns
-        false
+      def index_covers?(index, desired_index)
+        return false if desired_index[:using] && desired_index[:using] != index[:using]
+        info = index[:column_info]
+        columns = desired_index[:columns].zip(desired_index[:ops])
+        columns.all? do |column, op|
+          # TODO We're cheating on the `op` test here, and trusting that the types will line up.
+          info.key?(column) && op.nil? || info[column]['ops'].any? { |x| x['op'] == op }
+        end
       end
     end
   end

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -373,7 +373,9 @@ module PgHero
         columns = desired_index[:columns].zip(desired_index[:ops])
         columns.all? do |column, op|
           # TODO We're cheating on the `op` test here, and trusting that the types will line up.
-          info.key?(column) && op.nil? || info[column]['ops'].any? { |x| x['op'] == op }
+          if info.key?(column)
+            op.nil? || info[column]['ops'].any? { |x| x['op'] == op }
+          end
         end
       end
     end

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -365,8 +365,11 @@ module PgHero
       def index_subset?(indexed_columns, columns)
         indexed_columns.first(columns.size) == columns
       end
-      def index_covers?(indexed_columns, columns)
-        indexed_columns.first(columns.size) == columns
+
+      # REF https://www.postgresql.org/docs/13/indexes-multicolumn.html
+      def index_covers?(desired_index, column_info)
+        # indexed_columns.first(columns.size) == columns
+        false
       end
     end
   end

--- a/lib/pghero/methods/suggested_indexes.rb
+++ b/lib/pghero/methods/suggested_indexes.rb
@@ -30,9 +30,8 @@ module PgHero
               if best_index[:found]
                 index = best_index[:index]
                 best_index[:table_indexes] = indexes_by_table[index[:table]].to_a
-                cols = existing_columns[index[:using] || "btree"]
-                cols = cols.merge(existing_columns["gist"]) if true # TODO check column type for ltree
-                covering_index = cols[index[:table]].find { |e| index_covers?(e, index[:columns]) }
+
+                covering_index = existing_columns[index[:using] || "btree"][index[:table]].find { |e| index_covers?(e, index[:columns]) }
                 if covering_index
                   best_index[:covering_index] = covering_index
                   best_index[:explanation] = "Covered by index on (#{covering_index.join(", ")})"

--- a/lib/pghero/methods/suggested_indexes.rb
+++ b/lib/pghero/methods/suggested_indexes.rb
@@ -30,7 +30,9 @@ module PgHero
               if best_index[:found]
                 index = best_index[:index]
                 best_index[:table_indexes] = indexes_by_table[index[:table]].to_a
-                covering_index = existing_columns[index[:using] || "btree"][index[:table]].find { |e| index_covers?(e, index[:columns]) }
+                cols = existing_columns[index[:using] || "btree"]
+                cols = cols.merge(existing_columns["gist"]) if true # TODO check column type for ltree
+                covering_index = cols[index[:table]].find { |e| index_covers?(e, index[:columns]) }
                 if covering_index
                   best_index[:covering_index] = covering_index
                   best_index[:explanation] = "Covered by index on (#{covering_index.join(", ")})"

--- a/lib/pghero/methods/suggested_indexes.rb
+++ b/lib/pghero/methods/suggested_indexes.rb
@@ -157,6 +157,7 @@ module PgHero
                       index[:index] = {table: table, columns: final_where_columns, ops: final_where_ops}
 
                       # Only B-tree indexes can be used for ordering
+                      # https://www.postgresql.org/docs/13/indexes-ordering.html
                       index[:index][:using] = 'btree' if final_where_ops.include?(nil)
                     end
                   end

--- a/lib/pghero/methods/suggested_indexes.rb
+++ b/lib/pghero/methods/suggested_indexes.rb
@@ -28,7 +28,7 @@ module PgHero
                 covering_index = indexes_by_table[index[:table]].find { |idx| index_covers?(idx, index) }
                 if covering_index
                   best_index[:covering_index] = covering_index
-                  best_index[:explanation] = "Covered by index on (#{covering_index.join(", ")})"
+                  best_index[:explanation] = "Covered by index #{covering_index[:name]} (#{covering_index[:columns].join(", ")})"
                 end
               end
             end

--- a/test/best_index_test.rb
+++ b/test/best_index_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 
 class BestIndexTest < Minitest::Test
   def test_where
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id = 1"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "SELECT * FROM users WHERE city_id = 1"
   end
 
   def test_all_values
@@ -10,7 +10,7 @@ class BestIndexTest < Minitest::Test
     expected = {
       found: true,
       structure: {table: "users", where: [{column: "login_attempts", op: "="}], sort: [{column: "created_at", direction: "asc"}]},
-      index: {table: "users", columns: ["login_attempts", "created_at"]},
+      index: {table: "users", columns: ["login_attempts", "created_at"], ops: ['=', nil], using: 'btree'},
       rows: 5000,
       row_estimates: {"login_attempts (=)" => 167, "created_at (sort)" => 1},
       row_progression: [5000, 167, 0]
@@ -19,103 +19,103 @@ class BestIndexTest < Minitest::Test
   end
 
   def test_where_multiple_columns
-    assert_best_index ({table: "users", columns: ["city_id", "login_attempts"]}), "SELECT * FROM users WHERE city_id = 1 and login_attempts = 2"
+    assert_best_index ({table: "users", columns: ["city_id", "login_attempts"], ops: ['=', '=']}), "SELECT * FROM users WHERE city_id = 1 and login_attempts = 2"
   end
 
   def test_where_unique
-    assert_best_index ({table: "users", columns: ["email"]}), "SELECT * FROM users WHERE city_id = 1 AND email = 'person2@example.org'"
+    assert_best_index ({table: "users", columns: ["email"], ops: ['=']}), "SELECT * FROM users WHERE city_id = 1 AND email = 'person2@example.org'"
   end
 
   def test_order
-    assert_best_index ({table: "users", columns: ["created_at"]}), "SELECT * FROM users ORDER BY created_at"
+    assert_best_index ({table: "users", columns: ["created_at"], ops: [nil], using: 'btree'}), "SELECT * FROM users ORDER BY created_at"
   end
 
   def test_order_multiple
-    assert_best_index ({table: "users", columns: ["login_attempts", "created_at"]}), "SELECT * FROM users ORDER BY login_attempts, created_at"
+    assert_best_index ({table: "users", columns: ["login_attempts", "created_at"], ops: [nil, nil], using: 'btree'}), "SELECT * FROM users ORDER BY login_attempts, created_at"
   end
 
   def test_order_multiple_direction
-    assert_best_index ({table: "users", columns: ["login_attempts"]}), "SELECT * FROM users ORDER BY login_attempts DESC, created_at"
+    assert_best_index ({table: "users", columns: ["login_attempts"], ops: [nil], using: 'btree'}), "SELECT * FROM users ORDER BY login_attempts DESC, created_at"
   end
 
   def test_order_multiple_unique
-    assert_best_index ({table: "users", columns: ["id"]}), "SELECT * FROM users ORDER BY id, created_at"
+    assert_best_index ({table: "users", columns: ["id"], ops: [nil], using: 'btree'}), "SELECT * FROM users ORDER BY id, created_at"
   end
 
   def test_where_unique_order
-    assert_best_index ({table: "users", columns: ["email"]}), "SELECT * FROM users WHERE email = 'person2@example.org' ORDER BY created_at"
+    assert_best_index ({table: "users", columns: ["email"], ops: ['=']}), "SELECT * FROM users WHERE email = 'person2@example.org' ORDER BY created_at"
   end
 
   def test_where_order
-    assert_best_index ({table: "users", columns: ["login_attempts", "created_at"]}), "SELECT * FROM users WHERE login_attempts = 1 ORDER BY created_at"
+    assert_best_index ({table: "users", columns: ["login_attempts", "created_at"], ops: ['=', nil], using: 'btree'}), "SELECT * FROM users WHERE login_attempts = 1 ORDER BY created_at"
   end
 
   def test_where_order_unknown
-    assert_best_index ({table: "users", columns: ["login_attempts"]}), "SELECT * FROM users WHERE login_attempts = 1 ORDER BY NOW()"
+    assert_best_index ({table: "users", columns: ["login_attempts"], ops: ['=']}), "SELECT * FROM users WHERE login_attempts = 1 ORDER BY NOW()"
   end
 
   def test_where_in
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id IN (1, 2)"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "SELECT * FROM users WHERE city_id IN (1, 2)"
   end
 
   def test_like
-    assert_best_index ({table: "users", columns: ["email gist_trgm_ops"], using: "gist"}), "SELECT * FROM users WHERE email LIKE ?"
+    assert_best_index ({table: "users", columns: ["email"], opclasses: ['gist_trgm_ops'], ops: ['~~'], using: 'gist'}), "SELECT * FROM users WHERE email LIKE ?"
   end
 
   def test_like_where
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id = ? AND email LIKE ?"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "SELECT * FROM users WHERE city_id = ? AND email LIKE ?"
   end
 
   def test_like_where2
-    assert_best_index ({table: "users", columns: ["email gist_trgm_ops"], using: "gist"}), "SELECT * FROM users WHERE email LIKE ? AND active = ?"
+    assert_best_index ({table: "users", columns: ["email"], opclasses: ['gist_trgm_ops'], ops: ['~~'], using: "gist"}), "SELECT * FROM users WHERE email LIKE ? AND active = ?"
   end
 
   def test_ilike
-    assert_best_index ({table: "users", columns: ["email gist_trgm_ops"], using: "gist"}), "SELECT * FROM users WHERE email ILIKE ?"
+    assert_best_index ({table: "users", columns: ["email"], opclasses: ['gist_trgm_ops'], ops: ['~~*'], using: "gist"}), "SELECT * FROM users WHERE email ILIKE ?"
   end
 
   def test_not_equals
-    assert_best_index ({table: "users", columns: ["login_attempts"]}), "SELECT * FROM users WHERE city_id != ? and login_attempts = 2"
+    assert_best_index ({table: "users", columns: ["login_attempts"], ops: ['=']}), "SELECT * FROM users WHERE city_id != ? and login_attempts = 2"
   end
 
   def test_not_in
-    assert_best_index ({table: "users", columns: ["login_attempts"]}), "SELECT * FROM users WHERE city_id NOT IN (?) and login_attempts = 2"
+    assert_best_index ({table: "users", columns: ["login_attempts"], ops: ['=']}), "SELECT * FROM users WHERE city_id NOT IN (?) and login_attempts = 2"
   end
 
   def test_between
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id BETWEEN 1 AND 2"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['BETWEEN']}), "SELECT * FROM users WHERE city_id BETWEEN 1 AND 2"
   end
 
   def test_multiple_range
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id > ? and login_attempts > ?"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['>']}), "SELECT * FROM users WHERE city_id > ? and login_attempts > ?"
   end
 
   def test_where_prepared
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id = $1"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "SELECT * FROM users WHERE city_id = $1"
   end
 
   def test_where_normalized
-    assert_best_index ({table: "users", columns: ["city_id"]}), "SELECT * FROM users WHERE city_id = ?"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "SELECT * FROM users WHERE city_id = ?"
   end
 
   def test_is_null
-    assert_best_index ({table: "users", columns: ["zip_code"]}), "SELECT * FROM users WHERE zip_code IS NULL"
+    assert_best_index ({table: "users", columns: ["zip_code"], ops: ['null']}), "SELECT * FROM users WHERE zip_code IS NULL"
   end
 
   def test_is_null_equal
-    assert_best_index ({table: "users", columns: ["zip_code", "login_attempts"]}), "SELECT * FROM users WHERE zip_code IS NULL AND login_attempts = ?"
+    assert_best_index ({table: "users", columns: ["zip_code", "login_attempts"], ops: ['null', '=']}), "SELECT * FROM users WHERE zip_code IS NULL AND login_attempts = ?"
   end
 
   def test_is_not_null
-    assert_best_index ({table: "users", columns: ["login_attempts"]}), "SELECT * FROM users WHERE zip_code IS NOT NULL AND login_attempts = ?"
+    assert_best_index ({table: "users", columns: ["login_attempts"], ops: ['=']}), "SELECT * FROM users WHERE zip_code IS NOT NULL AND login_attempts = ?"
   end
 
   def test_update
-    assert_best_index ({table: "users", columns: ["city_id"]}), "UPDATE users SET email = 'test' WHERE city_id = 1"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "UPDATE users SET email = 'test' WHERE city_id = 1"
   end
 
   def test_delete
-    assert_best_index ({table: "users", columns: ["city_id"]}), "DELETE FROM users WHERE city_id = 1"
+    assert_best_index ({table: "users", columns: ["city_id"], ops: ['=']}), "DELETE FROM users WHERE city_id = 1"
   end
 
   def test_parse_error

--- a/test/suggested_indexes_test.rb
+++ b/test/suggested_indexes_test.rb
@@ -18,4 +18,10 @@ class SuggestedIndexesTest < Minitest::Test
     User.where("updated_at > ?", Time.now).to_a
     assert_equal [], database.suggested_indexes.map { |q| q.except(:queries, :details) }
   end
+
+  def test_ltree
+    query = "SELECT * FROM users WHERE tree_path = 'path1'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    pp result
+  end
 end

--- a/test/suggested_indexes_test.rb
+++ b/test/suggested_indexes_test.rb
@@ -11,7 +11,7 @@ class SuggestedIndexesTest < Minitest::Test
 
   def test_basic
     User.where(email: "person1@example.org").first
-    assert_equal [{table: "users", columns: ["email"]}], database.suggested_indexes.map { |q| q.except(:queries, :details) }
+    assert_equal [{table: "users", columns: ["email"], ops: ['=']}], database.suggested_indexes.map { |q| q.except(:queries, :details) }
   end
 
   def test_existing_index

--- a/test/suggested_indexes_test.rb
+++ b/test/suggested_indexes_test.rb
@@ -19,9 +19,101 @@ class SuggestedIndexesTest < Minitest::Test
     assert_equal [], database.suggested_indexes.map { |q| q.except(:queries, :details) }
   end
 
-  def test_ltree
-    query = "SELECT * FROM users WHERE tree_path = 'path1'"
+  def test_suggested_index_for_primary_key_equality
+    query = "SELECT * FROM users WHERE id = 1"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    pp result
+    summarize(result.merge(query: query))
+    assert_equal ['id'], result[:covering_index], 'Could not find covering primary key index'
+  end
+
+  def test_suggested_index_for_hash_index_equality
+    query = "SELECT * FROM users WHERE email = 'foo@example.com'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['email'], result[:covering_index], 'Could not find covering hash index for "=" operator'
+  end
+
+  def test_suggested_index_for_hash_index_equality_multiple_values
+    query = "SELECT * FROM users WHERE email IN ('foo@example.com', 'bar@example.com')"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['email'], result[:covering_index], 'Could not find covering hash index for "IN" operator'
+  end
+
+  def test_suggested_index_for_hash_index_match
+    query = "SELECT * FROM users WHERE email ~ 'example.com'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_nil result[:covering_index], 'Incorrectly used hash index to cover an unsupported operator'
+  end
+
+  def test_suggested_index_for_gist_trgm_index_equality
+    query = "SELECT * FROM users WHERE country = 'Test 1'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_nil result[:covering_index], 'Incorrectly used GiST index to cover an unsupported operator'
+  end
+
+  def test_suggested_index_for_gist_trgm_index_match
+    query = "SELECT * FROM users WHERE country ~ 'Test'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['country'], result[:covering_index], 'Could not find covering GiST index for "~" operator'
+  end
+
+  def test_suggested_index_for_gist_ltree_index_equality
+    query = "SELECT * FROM users WHERE path = 'b'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['path'], result[:covering_index], 'Could not find covering GiST index for ltree "=" operator'
+  end
+
+  def test_suggested_index_for_gist_ltree_index_match
+    query = "SELECT * FROM users WHERE path ~ 'b'::lquery"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['path'], result[:covering_index], 'Could not find covering GiST index for ltree "~" operator'
+  end
+
+  def test_suggested_index_for_gist_range_index_equality
+    query = "SELECT * FROM users WHERE range = '[0, 0]'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['range'], result[:covering_index], 'Could not find covering GiST index for range "=" operator'
+  end
+
+  def test_suggested_index_for_brin_index_equality
+    query = "SELECT * FROM users WHERE created_at = NOW()"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['created_at'], result[:covering_index], 'Could not find covering BRIN index for datetime "=" operator'
+  end
+
+  def test_suggested_index_for_gin_index_equality
+    query = "SELECT * FROM users WHERE metadata = '{}'::jsonb"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_nil result[:covering_index], 'Incorrectly used GIN index to cover an unsupported operator'
+  end
+
+  def test_suggested_index_for_gin_index_match
+    query = "SELECT * FROM users WHERE metadata ? 'favorite_color'"
+    result = database.suggested_indexes_by_query(queries: [query])[query]
+    summarize(result.merge(query: query))
+    assert_equal ['metadata'], result[:covering_index], 'Could not find covering BRIN index for JSONB "?" operator'
+  end
+
+  def summarize(result)
+    puts result[:query]
+    if result[:found]
+      puts "Found Index: #{result[:index].inspect}"
+      puts "Index Defined As: #{result[:table_indexes].find { |x| result[:index] < x }.inspect}"
+      puts "Covering Index: #{result[:covering_index] || '(None)'}"
+      puts "Explanation: #{result[:explanation] || '(None)'}"
+    else
+      puts "No useful indices found."
+    end
+
+    puts
   end
 end

--- a/test/suggested_indexes_test.rb
+++ b/test/suggested_indexes_test.rb
@@ -22,98 +22,96 @@ class SuggestedIndexesTest < Minitest::Test
   def test_suggested_index_for_primary_key_equality
     query = "SELECT * FROM users WHERE id = 1"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['id'], result[:covering_index], 'Could not find covering primary key index'
+
+    assert result[:covering_index], 'Could not find covering primary key index'
+    assert_equal ['id'], result[:covering_index][:columns]
   end
 
   def test_suggested_index_for_hash_index_equality
-    query = "SELECT * FROM users WHERE email = 'foo@example.com'"
+    query = "SELECT * FROM users WHERE zip_code = '90210'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['email'], result[:covering_index], 'Could not find covering hash index for "=" operator'
+
+    assert result[:covering_index], 'Could not find covering hash index for "=" operator'
+    assert_equal ['zip_code'], result[:covering_index][:columns]
   end
 
   def test_suggested_index_for_hash_index_equality_multiple_values
-    query = "SELECT * FROM users WHERE email IN ('foo@example.com', 'bar@example.com')"
+    query = "SELECT * FROM users WHERE zip_code IN ('90210', '99999')"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['email'], result[:covering_index], 'Could not find covering hash index for "IN" operator'
+
+    assert result[:covering_index], 'Could not find covering hash index for "IN" operator'
+    assert_equal ['zip_code'], result[:covering_index][:columns]
   end
 
-  def test_suggested_index_for_hash_index_match
-    query = "SELECT * FROM users WHERE email ~ 'example.com'"
+  def test_suggested_index_for_hash_index_gt
+    query = "SELECT * FROM users WHERE zip_code > '12345'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
+
     assert_nil result[:covering_index], 'Incorrectly used hash index to cover an unsupported operator'
   end
 
   def test_suggested_index_for_gist_trgm_index_equality
     query = "SELECT * FROM users WHERE country = 'Test 1'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
+
     assert_nil result[:covering_index], 'Incorrectly used GiST index to cover an unsupported operator'
   end
 
-  def test_suggested_index_for_gist_trgm_index_match
-    query = "SELECT * FROM users WHERE country ~ 'Test'"
-    result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['country'], result[:covering_index], 'Could not find covering GiST index for "~" operator'
-  end
+  # # NOTE Indexes are not suggested for this operator.
+  # def test_suggested_index_for_gist_trgm_index_match
+  #   query = "SELECT * FROM users WHERE country ~ 'Test'"
+  #   result = database.suggested_indexes_by_query(queries: [query])[query]
+  #
+  #   assert result[:covering_index], 'Could not find covering GiST index for "~" operator'
+  #   assert_equal ['country'], result[:covering_index][:columns]
+  # end
 
   def test_suggested_index_for_gist_ltree_index_equality
     query = "SELECT * FROM users WHERE path = 'b'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['path'], result[:covering_index], 'Could not find covering GiST index for ltree "=" operator'
+
+    assert result[:covering_index], 'Could not find covering GiST index for ltree "=" operator'
+    assert_equal ['path'], result[:covering_index][:columns]
   end
 
-  def test_suggested_index_for_gist_ltree_index_match
-    query = "SELECT * FROM users WHERE path ~ 'b'::lquery"
-    result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['path'], result[:covering_index], 'Could not find covering GiST index for ltree "~" operator'
-  end
+  # # NOTE Indexes are not suggested for this operator.
+  # def test_suggested_index_for_gist_ltree_index_match
+  #   query = "SELECT * FROM users WHERE path ~ 'b'::lquery"
+  #   result = database.suggested_indexes_by_query(queries: [query])[query]
+  #
+  #   assert result[:covering_index], 'Could not find covering GiST index for ltree "~" operator'
+  #   assert_equal ['path'], result[:covering_index][:columns]
+  # end
 
   def test_suggested_index_for_gist_range_index_equality
     query = "SELECT * FROM users WHERE range = '[0, 0]'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['range'], result[:covering_index], 'Could not find covering GiST index for range "=" operator'
+
+    assert result[:covering_index], 'Could not find covering GiST index for range "=" operator'
+    assert_equal ['range'], result[:covering_index][:columns]
   end
 
   def test_suggested_index_for_brin_index_equality
     query = "SELECT * FROM users WHERE created_at = NOW()"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['created_at'], result[:covering_index], 'Could not find covering BRIN index for datetime "=" operator'
+
+    assert result[:covering_index], 'Could not find covering BRIN index for datetime "=" operator'
+    assert_equal ['created_at'], result[:covering_index][:columns]
   end
 
   def test_suggested_index_for_gin_index_equality
     query = "SELECT * FROM users WHERE metadata = '{}'::jsonb"
     result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
+
     assert_nil result[:covering_index], 'Incorrectly used GIN index to cover an unsupported operator'
   end
 
-  def test_suggested_index_for_gin_index_match
-    query = "SELECT * FROM users WHERE metadata ? 'favorite_color'"
-    result = database.suggested_indexes_by_query(queries: [query])[query]
-    summarize(result.merge(query: query))
-    assert_equal ['metadata'], result[:covering_index], 'Could not find covering BRIN index for JSONB "?" operator'
-  end
-
-  def summarize(result)
-    puts result[:query]
-    if result[:found]
-      puts "Found Index: #{result[:index].inspect}"
-      puts "Index Defined As: #{result[:table_indexes].find { |x| result[:index] < x }.inspect}"
-      puts "Covering Index: #{result[:covering_index] || '(None)'}"
-      puts "Explanation: #{result[:explanation] || '(None)'}"
-    else
-      puts "No useful indices found."
-    end
-
-    puts
-  end
+  # # NOTE Indexes are not suggested for this operator.
+  # def test_suggested_index_for_gin_index_match
+  #   query = "SELECT * FROM users WHERE metadata ? 'favorite_color'"
+  #   result = database.suggested_indexes_by_query(queries: [query])[query]
+  #
+  #   assert result[:covering_index], 'Could not find covering BRIN index for JSONB "?" operator'
+  #   assert_equal ['metadata'], result[:covering_index][:columns]
+  # end
 end

--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -40,6 +40,9 @@ ActiveRecord::Migration.create_table :users, force: true do |t|
   t.string :country
   t.column :path, :ltree
   t.column :range, :int4range
+  t.column :description, :text
+  t.column :ts_description, :tsvector
+  t.column :last_known_ip, :inet
   t.column :metadata, :jsonb
   t.timestamp :created_at
   t.timestamp :updated_at
@@ -49,6 +52,8 @@ ActiveRecord::Migration.create_table :users, force: true do |t|
   t.index :zip_code, using: :hash
   t.index :path, using: :gist
   t.index :range, using: :gist
+  t.index :ts_description, using: :gist
+  t.index 'last_known_ip inet_ops', using: :gist
   t.index :created_at, using: :brin
   t.index :metadata, using: :gin
 end

--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -46,7 +46,7 @@ ActiveRecord::Migration.create_table :users, force: true do |t|
   t.index :id # duplicate index
   t.index :updated_at
   t.index "country gist_trgm_ops", using: :gist
-  t.index :email, using: :hash
+  t.index :zip_code, using: :hash
   t.index :path, using: :gist
   t.index :range, using: :gist
   t.index :created_at, using: :brin

--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -1,6 +1,7 @@
 ActiveRecord::Migration.verbose = ENV["VERBOSE"]
 
 ActiveRecord::Migration.enable_extension "pg_stat_statements"
+ActiveRecord::Migration.enable_extension "ltree"
 
 ActiveRecord::Migration.create_table :pghero_query_stats, force: true do |t|
   t.text :database
@@ -36,8 +37,10 @@ ActiveRecord::Migration.create_table :users, force: true do |t|
   t.string :email
   t.string :zip_code
   t.boolean :active
+  t.column :tree_path, :ltree
   t.timestamp :created_at
   t.timestamp :updated_at
   t.index :id # duplicate index
   t.index :updated_at
+  t.index :tree_path, using: :gist
 end

--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -37,10 +37,18 @@ ActiveRecord::Migration.create_table :users, force: true do |t|
   t.string :email
   t.string :zip_code
   t.boolean :active
-  t.column :tree_path, :ltree
+  t.string :country
+  t.column :path, :ltree
+  t.column :range, :int4range
+  t.column :metadata, :jsonb
   t.timestamp :created_at
   t.timestamp :updated_at
   t.index :id # duplicate index
   t.index :updated_at
-  t.index :tree_path, using: :gist
+  t.index "country gist_trgm_ops", using: :gist
+  t.index :email, using: :hash
+  t.index :path, using: :gist
+  t.index :range, using: :gist
+  t.index :created_at, using: :brin
+  t.index :metadata, using: :gin
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,7 @@ users =
       login_attempts: rand(30),
       zip_code: i % 40 == 0 ? nil : "12345",
       active: true,
+      tree_path: "path#{rand(30)}",
       created_at: Time.now - rand(50).days,
       updated_at: Time.now - rand(50).days
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,7 +41,7 @@ users =
   5000.times.map do |i|
     country_id = rand(50)
     city_id = i % 100
-    zip_code = i % 40 == 0 ? nil : "12345"
+    zip_code = i % 40 == 0 ? nil : "1234#{rand(10)}"
 
     {
       city_id: city_id,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,14 +39,20 @@ ActiveRecord::Base.connection.execute("ANALYZE states")
 
 users =
   5000.times.map do |i|
+    country_id = rand(50)
     city_id = i % 100
+    zip_code = i % 40 == 0 ? nil : "12345"
+
     {
       city_id: city_id,
       email: "person#{i}@example.org",
       login_attempts: rand(30),
-      zip_code: i % 40 == 0 ? nil : "12345",
+      zip_code: zip_code,
       active: true,
-      tree_path: "path#{rand(30)}",
+      country: "Test #{country_id}",
+      path: "#{country_id}.#{city_id}.#{zip_code || '00000'}",
+      range: (0..rand(5)),
+      metadata: { favorite_color: 'red' },
       created_at: Time.now - rand(50).days,
       updated_at: Time.now - rand(50).days
     }


### PR DESCRIPTION
Per discussion in #337, I've spent a little time digging into the guts of this.

Prior to this change, index recommendation worked (roughly) as:
* Parse a query.
* Find the set of columns that would provide the greatest estimated benefit.
* Load the existing indices from the database.
* Check to see if any existing — B-tree (with one exception) — index started with our desired columns.
  * If we found one, great.
  * If we didn't, you need a new index.

This had the shortcoming of bypassing indexes that were actually being used by the query, from hash indexes to BRIN indexes, to (as an example) a GiST index over an `ltree` column.  Rather than hardcode exceptions into this workflow, this PR updates the index recommendation flow to (roughly) as follows:
* Parse a query.
* Find the set of columns *and operators* used by this query that would provide the greatest estimated benefit.
* Load the existing indices *and the set of supported operators* from the database.
* Check to see if any existing index supports all of the desired operators on the desired columns.
  * If we found one, great.
  * If we didn't, you need a new index.

This allows *any* index that supports the appropriate operator to be considered "covering" the proposed index, and leads to a reduction in false recommendations.

---

Notably, this PR does not perform typechecking on the operator matches.  This is a "cheat" that could potentially represent an avenue for false recommendations in the event that the index supports an operator for _some_ types, but not the ones actually being used by the query.  As an additional improvement, it's possible to add _partial_ typechecking for most queries, but complete typechecking is technically impossible.

Similarly, there are some more advanced features of indexes that aren't being supported — particularly, expression indexes, partial indexes, and ordering operators (see: `pg_amop.amoppurpose`).

I have also authored this change without awareness of what your Ruby and Postgres version compatibility targets are, so there may be some backwards compatibility issues that will need addressed.