### PR TITLE
Ignore walsender type queries

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -34,7 +34,8 @@ module PgHero
         @inactive_replication_slots = @database.replication_slots.select { |r| !r[:active] }
       end
 
-      @autovacuum_queries, @long_running_queries = @database.long_running_queries.partition { |q| q[:query].starts_with?("autovacuum:") }
+      @walsender_queries, @long_running_queries_array = @database.long_running_queries.partition { |q| q[:backend_type]=="walsender"}
+      @autovacuum_queries, @long_running_queries = @long_running_queries_array.partition { |q| q[:query].starts_with?("autovacuum:") }
 
       connection_states = @database.connection_states
       @total_connections = connection_states.values.sum

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -26,6 +26,9 @@
     <% if @autovacuum_queries.any? %>
       <span class="tiny"><%= @autovacuum_queries.size %> autovacuum</span>
     <% end %>
+    <% if @walsender_queries.any? %>
+      <span class="tiny"><%= @walsender_queries.size %> walsender</span>
+    <% end %>
   </div>
   <% if @extended %>
     <div class="alert alert-<%= @good_cache_rate ? "success" : "warning" %>">

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -16,7 +16,8 @@ module PgHero
           FROM
             pg_stat_activity
           WHERE
-            state <> 'idle'
+           #{server_version_num >= 100000 ? "backend_type NOT IN('walsender')" : "NOT EXISTS (SELECT 1 FROM pg_stat_replication r WHERE r.pid = pg_stat_activity.pid AND r.usesysid = pg_stat_activity.usesysid)"}            
+            AND state <> 'idle'
             AND pid <> pg_backend_pid()
             AND datname = current_database()
             #{min_duration ? "AND NOW() - COALESCE(query_start, xact_start) > interval '#{min_duration.to_i} seconds'" : nil}

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -12,12 +12,12 @@ module PgHero
             query,
             COALESCE(query_start, xact_start) AS started_at,
             EXTRACT(EPOCH FROM NOW() - COALESCE(query_start, xact_start)) * 1000.0 AS duration_ms,
-            usename AS user
+            usename AS user,
+            #{server_version_num >= 100000 ? "backend_type" : "NULL AS backend_type"}
           FROM
             pg_stat_activity
           WHERE
-           #{server_version_num >= 100000 ? "backend_type NOT IN('walsender')" : "NOT EXISTS (SELECT 1 FROM pg_stat_replication r WHERE r.pid = pg_stat_activity.pid AND r.usesysid = pg_stat_activity.usesysid)"}            
-            AND state <> 'idle'
+            state <> 'idle'
             AND pid <> pg_backend_pid()
             AND datname = current_database()
             #{min_duration ? "AND NOW() - COALESCE(query_start, xact_start) > interval '#{min_duration.to_i} seconds'" : nil}


### PR DESCRIPTION
<img width="729" alt="Screen Shot 2020-12-15 at 1 50 36 PM" src="https://user-images.githubusercontent.com/3464623/102265289-8a5cd900-3edc-11eb-9d7a-c9c180f9e2b1.png">

Can we Ignore walsender process queries ?

Logical replication processes are walsender processes that can have the appearance of a long-running query if not specially treated.  These should be ignored as they will always show up at the top of the slow query list otherwise.  They have backend_type "walsender" (for 10+) and can be found using pg_stat_replication for 9.6.