### PR TITLE
Change Kill module to use pg_cancel_backend

### DIFF
--- a/lib/pghero/methods/kill.rb
+++ b/lib/pghero/methods/kill.rb
@@ -2,7 +2,7 @@ module PgHero
   module Methods
     module Kill
       def kill(pid)
-        select_one("SELECT pg_terminate_backend(#{pid.to_i})")
+        select_one("SELECT pg_cancel_backend(#{pid.to_i})")
       end
 
       def kill_long_running_queries(min_duration: nil)
@@ -13,7 +13,7 @@ module PgHero
       def kill_all
         select_all <<-SQL
           SELECT
-            pg_terminate_backend(pid)
+            pg_cancel_backend(pid)
           FROM
             pg_stat_activity
           WHERE


### PR DESCRIPTION
Instead of killing the process (and subsequently the connection) when hitting the "Kill" button in PgHero, isn't it better and safer for a running application if we can just kill the query only?