### PR TITLE
Adjust time format in maintenance listing table to include year

### DIFF
--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -27,14 +27,14 @@ module PgHero
       ret
     end
 
-    def formatted_vacuum_times(time)
-      content_tag(:span, title: formatted_date_time(time)) do
+    def pghero_formatted_vacuum_times(time)
+      content_tag(:span, title: pghero_formatted_date_time(time)) do
         "#{time_ago_in_words(time.in_time_zone(@time_zone))} ago"
       end
     end
 
-    def formatted_date_time(time)
-      l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M"
+    def pghero_formatted_date_time(time)
+      l time.in_time_zone(@time_zone), format: :long
     end
   end
 end

--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -26,5 +26,15 @@ module PgHero
       ret << ", column: #{columns.inspect}" if columns
       ret
     end
+
+    def formatted_vacuum_times(time)
+      content_tag(:span, title: formatted_date_time(time)) do
+        "#{time_ago_in_words(time.in_time_zone(@time_zone))} ago"
+      end
+    end
+
+    def formatted_date_time(time)
+      l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M"
+    end
   end
 end

--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -24,7 +24,7 @@
           <td>
             <% time = [table[:last_autovacuum], table[:last_vacuum]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %I:%M %p" %>
+              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M" %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>
@@ -32,7 +32,7 @@
           <td>
             <% time = [table[:last_autoanalyze], table[:last_analyze]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %I:%M %p" %>
+              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M" %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>

--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -24,7 +24,7 @@
           <td>
             <% time = [table[:last_autovacuum], table[:last_vacuum]].compact.max %>
             <% if time %>
-              <%= formatted_vacuum_times(time) %>
+              <%= pghero_formatted_vacuum_times(time) %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>
@@ -32,7 +32,7 @@
           <td>
             <% time = [table[:last_autoanalyze], table[:last_analyze]].compact.max %>
             <% if time %>
-              <%= formatted_vacuum_times(time) %>
+              <%= pghero_formatted_vacuum_times(time) %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>

--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -24,7 +24,7 @@
           <td>
             <% time = [table[:last_autovacuum], table[:last_vacuum]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M" %>
+              <%= formatted_vacuum_times(time) %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>
@@ -32,7 +32,7 @@
           <td>
             <% time = [table[:last_autoanalyze], table[:last_analyze]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %H:%M" %>
+              <%= formatted_vacuum_times(time) %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>

--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -24,7 +24,7 @@
           <td>
             <% time = [table[:last_autovacuum], table[:last_vacuum]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: :short %>
+              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %I:%M %p" %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>
@@ -32,7 +32,7 @@
           <td>
             <% time = [table[:last_autoanalyze], table[:last_analyze]].compact.max %>
             <% if time %>
-              <%= l time.in_time_zone(@time_zone), format: :short %>
+              <%= l time.in_time_zone(@time_zone), format: "%d %b %Y %I:%M %p" %>
             <% else %>
               <span class="text-muted">Unknown</span>
             <% end %>


### PR DESCRIPTION
Fixes #363 

Rails only includes the following time format options: https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-US.yml#L211-L214

To make the timestamp displayed for the last vacuum or analyze less ambiguous I decided to add a year. I provided a custom format string to maintain the existing "day short_month ... 24-hour clock time" format instead of using `:long` which would completely change the order.

Example:

```ruby
# Old
I18n.l 3.years.ago.in_time_zone("UTC"), format: :short
=> "23 Feb 23:57"

# New
I18n.l 3.years.ago.in_time_zone("UTC"), format: "%d %b %Y %H:%M"
=> "23 Feb 2018 23:57"
```