### PR TITLE
Skip tests that test disabled features

### DIFF
--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -27,11 +27,13 @@ class ControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_queries
+    skip unless database.query_stats_enabled?
     get pg_hero.queries_path
     assert_response :success
   end
 
   def test_show_query
+    skip unless database.query_stats_enabled?
     get pg_hero.show_query_path(query_hash: 123)
     assert_response :success
   end

--- a/test/indexes_test.rb
+++ b/test/indexes_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class IndexesTest < Minitest::Test
   def test_index_hit_rate
+    skip unless database.system_stats_enabled?
     assert database.index_hit_rate
   end
 

--- a/test/query_stats_test.rb
+++ b/test/query_stats_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class QueryStatsTest < Minitest::Test
   def test_query_stats
+    skip unless database.query_stats_enabled?
     assert database.query_stats
   end
 
@@ -10,6 +11,7 @@ class QueryStatsTest < Minitest::Test
   end
 
   def test_query_stats_enabled
+    skip unless database.query_stats_enabled?
     assert database.query_stats_enabled?
   end
 
@@ -18,6 +20,7 @@ class QueryStatsTest < Minitest::Test
   end
 
   def test_query_stats_readable?
+    skip unless database.query_stats_enabled?
     assert database.query_stats_readable?
   end
 
@@ -27,11 +30,13 @@ class QueryStatsTest < Minitest::Test
   end
 
   def test_reset_query_stats
+    skip unless database.query_stats_enabled?
     assert database.reset_query_stats
   end
 
   def test_reset_query_stats_database
     skip unless gte12?
+    skip unless database.query_stats_enabled?
 
     assert database.reset_query_stats
     ActiveRecord::Base.connection.select_all("SELECT 1")
@@ -54,6 +59,7 @@ class QueryStatsTest < Minitest::Test
 
   def test_reset_query_stats_user
     skip unless gte12?
+    skip unless database.query_stats_enabled?
 
     assert database.reset_query_stats
     ActiveRecord::Base.connection.select_all("SELECT 1")
@@ -76,6 +82,7 @@ class QueryStatsTest < Minitest::Test
 
   def test_reset_query_stats_query_hash
     skip unless gte12?
+    skip unless database.query_stats_enabled?
 
     assert database.reset_query_stats
     ActiveRecord::Base.connection.select_all("SELECT 1")
@@ -105,6 +112,7 @@ class QueryStatsTest < Minitest::Test
   end
 
   def test_capture_query_stats
+    skip unless database.query_stats_enabled?
     PgHero::QueryStats.delete_all
     refute PgHero::QueryStats.any?
     assert database.capture_query_stats

--- a/test/suggested_indexes_test.rb
+++ b/test/suggested_indexes_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class SuggestedIndexesTest < Minitest::Test
   def setup
+    skip unless database.query_stats_enabled?
     database.reset_query_stats
   end
 
@@ -56,6 +57,7 @@ class SuggestedIndexesTest < Minitest::Test
   end
 
   def test_range
+    skip unless database.suggested_indexes_enabled?
     query = "SELECT * FROM users WHERE range = '[0, 0]'"
     result = database.suggested_indexes_by_query(queries: [query])[query]
     assert_equal ["range"], result[:covering_index]

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class TablesTest < Minitest::Test
   def test_table_hit_rate
+    skip unless database.system_stats_enabled?
     assert database.table_hit_rate
   end
 


### PR DESCRIPTION
Locally for me, I get a lot of test failures. I'm wondering whether
checking for features being enabled before trying to call code that
depends on that feature being enabled is a better move. This way pghero
could have 100% passing test suite even without features like query
stats, suggested indexes, or system stats enabled.