### PR TITLE
Add Scheduled Jobs

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -9,6 +9,7 @@ module PgHero
     before_action :check_api
     before_action :set_database
     before_action :set_query_stats_enabled
+    before_action :set_scheduled_jobs_enabled
     before_action :set_show_details, only: [:index, :queries, :show_query]
     before_action :ensure_query_stats, only: [:queries]
 
@@ -375,6 +376,11 @@ module PgHero
       redirect_backward alert: "The database user does not have permission to reset query stats"
     end
 
+    def scheduled_jobs
+      @scheduled_jobs = @database.scheduled_jobs
+      @job_run_details = @database.job_run_details
+    end
+
     protected
 
     def redirect_backward(options = {})
@@ -401,6 +407,10 @@ module PgHero
       @query_stats_enabled = @database.query_stats_enabled?
       @system_stats_enabled = @database.system_stats_enabled?
       @replica = @database.replica?
+    end
+
+    def set_scheduled_jobs_enabled
+      @scheduled_jobs_enabled = @database.pg_cron_extension_enabled? && @database.pg_cron_readable?
     end
 
     def set_suggested_indexes(min_average_time = 0, min_calls = 0)

--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -45,6 +45,9 @@
             <% end %>
             <li class="<%= controller.action_name == "explain" ? "active" : "" %>"><%= link_to "Explain", explain_path %></li>
             <li class="<%= controller.action_name == "tune" ? "active" : "" %>"><%= link_to "Tune", tune_path %></li>
+            <% if @scheduled_jobs_enabled %>
+              <li class="<%= controller.action_name == "scheduled_jobs" ? "active" : "" %>"><%= link_to "Scheduled Jobs", scheduled_jobs_path %></li>
+            <% end %>
           </ul>
 
           <% if @databases.size > 1 %>

--- a/app/views/pg_hero/home/scheduled_jobs.html.erb
+++ b/app/views/pg_hero/home/scheduled_jobs.html.erb
@@ -1,0 +1,56 @@
+<div class="content">
+  <h1>Scheduled Jobs</h1>
+
+  <p><%= pluralize(@scheduled_jobs.size, "scheduled job") %></p>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th style="width: 20%;">Job ID</th>
+        <th style="width: 20%;">Command</th>
+        <th style="width: 20%;">Schedule</th>
+        <th style="width: 20%;">Active</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @scheduled_jobs.each do |table| %>
+        <tr>
+          <td><%= table[:jobid] %></td>
+          <td><%= table[:command] %></td>
+          <td><%= table[:schedule] %></td>
+          <td><%= table[:active] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <h1>Job Run Details</h1>
+  <table class="table">
+    <thead>
+      <tr>
+        <th style="width: 20%;">Job ID</th>
+        <th style="width: 20%;">Run ID</th>
+        <th style="width: 20%;">PID</th>
+        <th style="width: 20%;">Command</th>
+        <th style="width: 20%;">Status</th>
+        <th style="width: 20%;">Message</th>
+        <th style="width: 20%;">Start</th>
+        <th style="width: 20%;">End</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @job_run_details.each do |table| %>
+        <tr>
+          <td><%= table[:jobid] %></td>
+          <td><%= table[:runid] %></td>
+          <td><%= table[:job_pid] %></td>
+          <td><%= table[:command] %></td>
+          <td><%= table[:status] %></td>
+          <td><%= table[:return_message] %></td>
+          <td><%= time_ago_in_words(table[:start_time]) %></td>
+          <td><%= time_ago_in_words(table[:end_time]) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ PgHero::Engine.routes.draw do
     get "tune", to: "home#tune"
     get "connections", to: "home#connections"
     get "maintenance", to: "home#maintenance"
+    get "scheduled_jobs", to: "home#scheduled_jobs"
     post "kill", to: "home#kill"
     post "kill_long_running_queries", to: "home#kill_long_running_queries"
     post "kill_all", to: "home#kill_all"

--- a/guides/Scheduled-Jobs.md
+++ b/guides/Scheduled-Jobs.md
@@ -1,0 +1,32 @@
+# Scheduled Jobs
+
+The [pg_cron extension](https://github.com/citusdata/pg_cron) is used for scheduled jobs.
+
+## Installation
+
+On a Mac, the extension may be built from source.
+
+Add the extension to the `shared_preload_libraries` in `postgresql.conf` and restart.
+
+Run `CREATE EXTENSION pg_cron`
+
+## Configuration
+
+Specify the database to run scheduled jobs for.
+
+```
+# add to postgresql.conf
+cron.database_name = `postgres`
+```
+
+## Adding Jobs
+
+To vacuum <tablename> manually, add an entry that looks like this.
+
+```
+SELECT cron.schedule('0 10 * * *', 'VACUUM tablename');
+```
+
+Confirm the entry was added on the Scheduled Jobs tab.
+
+Any runs for this job will be displayed in the Scheduled Jobs section as well.

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -20,6 +20,7 @@ require "pghero/methods/suggested_indexes"
 require "pghero/methods/system"
 require "pghero/methods/tables"
 require "pghero/methods/users"
+require "pghero/methods/scheduled_jobs"
 
 require "pghero/database"
 require "pghero/engine" if defined?(Rails)
@@ -64,7 +65,8 @@ module PgHero
       :reset_query_stats, :reset_stats, :running_queries, :secret_access_key, :sequence_danger, :sequences, :settings,
       :slow_queries, :space_growth, :ssl_used?, :stats_connection, :suggested_indexes, :suggested_indexes_by_query,
       :suggested_indexes_enabled?, :system_stats_enabled?, :table_caching, :table_hit_rate, :table_stats,
-      :total_connections, :transaction_id_danger, :unused_indexes, :unused_tables, :write_iops_stats
+      :total_connections, :transaction_id_danger, :unused_indexes, :unused_tables, :write_iops_stats,
+      :pg_cron_extension_enabled?, :pg_cron_readable?, :scheduled_jobs, :job_run_details
 
     def time_zone=(time_zone)
       @time_zone = time_zone.is_a?(ActiveSupport::TimeZone) ? time_zone : ActiveSupport::TimeZone[time_zone.to_s]

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -7,6 +7,7 @@ module PgHero
     include Methods::Indexes
     include Methods::Kill
     include Methods::Maintenance
+    include Methods::ScheduledJobs
     include Methods::Queries
     include Methods::QueryStats
     include Methods::Replication

--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -46,6 +46,17 @@ module PgHero
         false
       end
 
+      def pg_cron_extension_enabled?
+        select_one("SELECT COUNT(*) AS count FROM pg_extension WHERE extname = 'pg_cron'") > 0
+      end
+
+      def pg_cron_readable?
+        select_all("SELECT * FROM cron.job LIMIT 1")
+        true
+      rescue ActiveRecord::StatementInvalid
+        false
+      end
+
       def enable_query_stats
         execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
         true

--- a/lib/pghero/methods/scheduled_jobs.rb
+++ b/lib/pghero/methods/scheduled_jobs.rb
@@ -1,0 +1,17 @@
+module PgHero
+  module Methods
+    module ScheduledJobs
+      def scheduled_jobs
+        select_all <<-SQL
+          SELECT * from cron.job
+        SQL
+      end
+
+      def job_run_details
+        select_all <<-SQL
+          SELECT * from cron.job_run_details
+        SQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
Scheduled Jobs are powered by pg_cron

Add a Documentation page for how to install, configure, and create
scheduled jobs

The Scheduled Jobs tab/page makes it easy to browse created jobs, and
their individual runs. By presenting runs we can more easily confirm
they are running and spot issues.

![image](https://user-images.githubusercontent.com/2161008/153795047-3874fd01-5db7-44f5-8a8f-96b58b8802a2.png)
