### PR TITLE
Add support for rendering assets without Sprockets (or Propshaft)

### DIFF
--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -4,13 +4,19 @@
     <title><%= [@databases.size > 1 ? @database.name : "PgHero", @title].compact.join(" / ") %></title>
 
     <meta charset="utf-8" />
-    <%= favicon_link_tag "pghero/favicon.png" %>
+
     <% if defined?(Propshaft::Railtie) %>
-      <%= stylesheet_link_tag "pghero/nouislider", "pghero/arduino-light", "pghero/application" %>
-      <%= javascript_include_tag "pghero/jquery", "pghero/nouislider", "pghero/Chart.bundle", "pghero/chartkick", "pghero/highlight.pack", "pghero/application" %>
+      <%= favicon_link_tag PgHero.assets.favicon_source, type: PgHero.assets.favicon_type %>
+      <%= stylesheet_link_tag *PgHero.assets.stylesheet_sources %>
+      <%= javascript_include_tag *PgHero.assets.javascript_sources %>
+    <% elsif defined?(Sprockets) %>
+      <%= favicon_link_tag PgHero.assets.favicon_source, type: PgHero.assets.favicon_type %>
+      <%= stylesheet_link_tag PgHero.assets.stylesheet_source %>
+      <%= javascript_include_tag PgHero.assets.javascript_source %>
     <% else %>
-      <%= stylesheet_link_tag "pghero/application" %>
-      <%= javascript_include_tag "pghero/application" %>
+      <%= tag :link, rel: :icon, href: PgHero.assets.favicon_data_uri, type: PgHero.assets.favicon_type %>
+      <%= content_tag :style, PgHero.assets.stylesheet_content.html_safe %>
+      <%= content_tag :script, PgHero.assets.javascript_content.html_safe %>
     <% end %>
   </head>
   <body>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -26,6 +26,7 @@ require "pghero/engine" if defined?(Rails)
 require "pghero/version"
 
 module PgHero
+  autoload :Assets, "pghero/assets"
   autoload :Connection, "pghero/connection"
   autoload :Stats, "pghero/stats"
   autoload :QueryStats, "pghero/query_stats"
@@ -227,6 +228,11 @@ module PgHero
     # Rails 7.0 deprecates `include_replicas` for `include_hidden`
     def include_replicas_key
       ActiveRecord::VERSION::MAJOR >= 7 ? :include_hidden : :include_replicas
+    end
+
+    # private
+    def assets
+      @assets ||= PgHero::Assets.new(PgHero::Engine.root.join("app/assets"))
     end
 
     private

--- a/lib/pghero/assets.rb
+++ b/lib/pghero/assets.rb
@@ -1,0 +1,57 @@
+module PgHero
+  class Assets
+    JAVASCRIPTS = %w(jquery nouislider Chart.bundle chartkick highlight.pack application).map { |name| "pghero/#{name}.js" }.freeze
+    STYLESHEETS = %w(nouislider arduino-light application).map { |name| "pghero/#{name}.css" }.freeze
+    FAVICON = "pghero/favicon.png".freeze
+
+    attr_reader :javascript_root, :stylesheet_root, :image_root
+
+    def initialize(root)
+      @javascript_root = root.join("javascripts")
+      @stylesheet_root = root.join("stylesheets")
+      @image_root = root.join("images")
+    end
+
+    # Javacript
+
+    def javascript_sources
+      JAVASCRIPTS
+    end
+
+    def javascript_source
+      javascript_sources.last
+    end
+
+    def javascript_content
+      javascript_sources.map { |source| javascript_root.join(source).read }.join("\n\n").freeze
+    end
+
+    # Stylesheets
+
+    def stylesheet_sources
+      STYLESHEETS
+    end
+
+    def stylesheet_source
+      stylesheet_sources.last
+    end
+
+    def stylesheet_content
+      stylesheet_sources.map { |source| stylesheet_root.join(source).read }.join("\n\n").freeze
+    end
+
+    # Favicon
+
+    def favicon_source
+      FAVICON
+    end
+
+    def favicon_type
+      @favicon_type ||= "image/#{favicon_source.split(".").last}".freeze
+    end
+
+    def favicon_data_uri
+      @favicon_data_uri ||= "data:#{favicon_type};base64,#{Base64.strict_encode64(image_root.join(favicon_source).binread)}".freeze
+    end
+  end
+end

--- a/lib/pghero/engine.rb
+++ b/lib/pghero/engine.rb
@@ -6,14 +6,14 @@ module PgHero
       # check if Rails api mode
       if app.config.respond_to?(:assets)
         if defined?(Sprockets) && Sprockets::VERSION >= "4"
-          app.config.assets.precompile << "pghero/application.js"
-          app.config.assets.precompile << "pghero/application.css"
-          app.config.assets.precompile << "pghero/favicon.png"
+          app.config.assets.precompile << PgHero.assets.javascript_source
+          app.config.assets.precompile << PgHero.assets.stylesheet_source
+          app.config.assets.precompile << PgHero.assets.favicon_source
         else
           # use a proc instead of a string
-          app.config.assets.precompile << proc { |path| path == "pghero/application.js" }
-          app.config.assets.precompile << proc { |path| path == "pghero/application.css" }
-          app.config.assets.precompile << proc { |path| path == "pghero/favicon.png" }
+          app.config.assets.precompile << proc { |path| path == PgHero.assets.javascript_source }
+          app.config.assets.precompile << proc { |path| path == PgHero.assets.stylesheet_source }
+          app.config.assets.precompile << proc { |path| path == PgHero.assets.favicon_source }
         end
       end
 

--- a/test/assets_test.rb
+++ b/test/assets_test.rb
@@ -1,0 +1,61 @@
+require_relative "test_helper"
+
+class AssetsTest < Minitest::Test
+  def test_javascript_source
+    assert_equal "pghero/application.js", PgHero.assets.javascript_source
+  end
+
+  def test_javascript_sources
+    sources = PgHero.assets.javascript_sources
+    assert_equal "pghero/application.js", sources.last
+    assert_operator sources.size, :>, 1
+    sources.each do |source|
+      assert_match /^pghero\/[^\/]+\.js$/, source
+    end
+  end
+
+  def test_javascript_content
+    content = PgHero.assets.javascript_content
+    assert_kind_of String, content
+    assert_operator content.size, :>, 0
+    PgHero.assets.javascript_sources.each do |source|
+      source_file = PgHero::Engine.root.join("app/assets/javascripts/#{source}")
+      assert content.include?(source_file.read), "Expected javascript_content to include the contents of #{source_file.basename}"
+    end
+  end
+
+  def test_stylesheet_source
+    assert_equal "pghero/application.css", PgHero.assets.stylesheet_source
+  end
+
+  def test_stylesheet_sources
+    sources = PgHero.assets.stylesheet_sources
+    assert_equal "pghero/application.css", sources.last
+    assert_operator sources.size, :>, 1
+    sources.each do |source|
+      assert_match /^pghero\/[^\/]+\.css$/, source
+    end
+  end
+
+  def test_stylesheet_content
+    content = PgHero.assets.stylesheet_content
+    assert_kind_of String, content
+    assert_operator content.size, :>, 0
+    PgHero.assets.stylesheet_sources.each do |source|
+      source_file = PgHero::Engine.root.join("app/assets/stylesheets/#{source}")
+      assert content.include?(source_file.read), "Expected stylesheet_content to include the contents of #{source_file.basename}"
+    end
+  end
+
+  def test_favicon_source
+    assert_equal "pghero/favicon.png", PgHero.assets.favicon_source
+  end
+
+  def test_favicon_type
+    assert_equal "image/png", PgHero.assets.favicon_type
+  end
+
+  def test_favicon_data_uri
+    assert_match /^data:image\/png;base64,\w{20,}+/, PgHero.assets.favicon_data_uri
+  end
+end


### PR DESCRIPTION
First, thank you for PgHero! It’s immensely useful and helpful.

This PR adds support for running PgHero in applications that don’t use Sprockets (or Propshaft) by inlining its CSS, JavaScript, and images (the favicon) when neither are present, resulting in `<head>` output like:

```html
<link rel="icon" href="data:image/png;base64,iVBORw[…SNIP…]gg==" type="image/png">
<style>/* app/assets/stylesheets/pghero/*.css files concatenated */</style>
<script>/* app/assets/javascripts/pghero/*.js files concatenated */</script>
```

Fixes #215
Fixes #319
Fixes #371
Resolves #148

Thanks for your consideration! ❤️