### PR TITLE
Remove comment from home/space

### DIFF
--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -10,11 +10,9 @@
     </script>
   <% end %>
 
-  <!--
   <% if @index_bloat.any? %>
     <p>Check out <%= link_to "index bloat", index_bloat_path %> for an easy way to reclaim space.</p>
   <% end %>
-  -->
 
   <% if @unused_indexes.any? %>
     <p>


### PR DESCRIPTION
[better_html](https://github.com/Shopify/better-html) does not like it and raises an exception

```
Ruby statement not allowed. In 'comment' on line 14 column 0: <% if @index_bloat.any?
```

Either delete comment (chosen in this PR) or remove the `if`