### PR TITLE
Fix rake calls in Docker docs

### DIFF
--- a/guides/Docker.md
+++ b/guides/Docker.md
@@ -55,7 +55,7 @@ This table can be in the current database or another database. If another databa
 Schedule the task below to run every 5 minutes.
 
 ```sh
-docker run -ti -e DATABASE_URL=... ankane/pghero bin/rake pghero:capture_query_stats
+docker run -ti -e DATABASE_URL=... ankane/pghero rake pghero:capture_query_stats
 ```
 
 After this, a time range slider will appear on the Queries tab.
@@ -63,7 +63,7 @@ After this, a time range slider will appear on the Queries tab.
 The query stats table can grow large over time. Remove old stats with:
 
 ```sh
-docker run -ti -e DATABASE_URL=... ankane/pghero bin/rake pghero:clean_query_stats
+docker run -ti -e DATABASE_URL=... ankane/pghero rake pghero:clean_query_stats
 ```
 
 ## Historical Space Stats
@@ -85,7 +85,7 @@ CREATE INDEX ON "pghero_space_stats" ("database", "captured_at");
 Schedule the task below to run once a day.
 
 ```sh
-docker run -ti -e DATABASE_URL=... ankane/pghero bin/rake pghero:capture_space_stats
+docker run -ti -e DATABASE_URL=... ankane/pghero rake pghero:capture_space_stats
 ```
 
 ## System Stats


### PR DESCRIPTION
After running into issues while trying to set up the `capture_query_stats` cron job in Docker, I found that the Docker image does not contain a `bin` folder in the `app` directory:

```
❯ docker run -ti ankane/pghero /bin/sh
/app # ls -la
total 84
drwxr-xr-x    1 root     root          4096 Oct 10 01:49 .
drwxr-xr-x    1 root     root          4096 Dec  5 13:33 ..
-rw-r--r--    1 root     root            23 Jun  4  2020 .gitignore
-rw-r--r--    1 root     root           649 Sep 13 22:08 .pkgr.yml
-rw-r--r--    1 root     root           577 Sep 13 18:53 Dockerfile
-rw-r--r--    1 root     root           353 Oct 10 01:46 Gemfile
-rw-r--r--    1 root     root          7162 Oct 10 01:48 Gemfile.lock
-rw-r--r--    1 root     root          1079 Sep 13 18:51 LICENSE.txt
-rw-r--r--    1 root     root            40 Jun  4  2020 Procfile
-rw-r--r--    1 root     root            60 Jun  4  2020 README.md
-rw-r--r--    1 root     root           249 Jun  4  2020 Rakefile
-rw-r--r--    1 root     root          2957 Sep 13 22:19 Vagrantfile
drwxr-xr-x    3 root     root          4096 Oct 10 01:49 app
-rw-r--r--    1 root     root           565 Jun  4  2020 app.json
drwxr-xr-x    2 root     root          4096 Oct 10 01:49 config
-rw-r--r--    1 root     root           205 Jun  4  2020 config.ru
drwxr-xr-x    2 root     root          4096 Oct 10 01:49 gemfiles
drwxr-xr-x    1 root     root          4096 Oct 10 01:54 public
drwxr-xr-x    1 root     root          4096 Oct 10 01:54 tmp
```

It does seem like `rake` is available on the `$PATH`, so replacing `bin/rake` with `rake` works!