### PR TITLE
For PostgreSQL 14+, provide DROP INDEX migration lines that use CONCURRENTLY

### DIFF
--- a/app/helpers/pg_hero/home_helper.rb
+++ b/app/helpers/pg_hero/home_helper.rb
@@ -16,6 +16,15 @@ module PgHero
       json_escape(value.to_json(root: false)).html_safe
     end
 
+    def pghero_drop_idx_concurrently_explanation
+      if @database.drop_idx_concurrently_supported?
+        ret =  "<h2>Tip: Perform DROP INDEX operations using CONCURRENTLY</h2>"
+        ret << "<ul><li>Add <code>disable_ddl_transaction!</code> to your migration</li>"
+        ret << "<li>Add <code>algorithm: :concurrently</code> to each <code>remove_index</code></li></ul>"
+        ret.html_safe
+      end
+    end
+
     def pghero_remove_index(query)
       if query[:columns]
         columns = query[:columns].map(&:to_sym)
@@ -24,6 +33,7 @@ module PgHero
       ret = String.new("remove_index #{query[:table].to_sym.inspect}")
       ret << ", name: #{(query[:name] || query[:index]).to_s.inspect}"
       ret << ", column: #{columns.inspect}" if columns
+      ret << ", algorithm: :concurrently" if @database.drop_idx_concurrently_supported?
       ret
     end
 

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -390,6 +390,9 @@
 
     <div id="migration2" style="display: none;">
       <pre>rails generate migration remove_unneeded_indexes</pre>
+      <% if @database.drop_idx_concurrently_supported? %>
+        <p><%= pghero_drop_idx_concurrently_explanation %></p>
+      <% end %>
       <p>And paste</p>
       <pre style="overflow: scroll; white-space: pre; word-break: normal;"><% @duplicate_indexes.each do |query| %>
 <%= pghero_remove_index(query[:unneeded_index]) %><% end %></pre>

--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -31,6 +31,9 @@
 
     <div id="migration" style="display: none;">
       <pre>rails generate migration remove_unused_indexes</pre>
+      <% if @database.drop_idx_concurrently_supported? %>
+        <p><%= pghero_drop_idx_concurrently_explanation %></p>
+      <% end %>
       <p>And paste</p>
       <pre style="overflow: scroll; white-space: pre; word-break: normal;"><% @unused_indexes.sort_by { |q| [-q[:size_bytes], q[:index]] }.each do |query| %>
 <%= pghero_remove_index(query) %><% end %></pre>

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -34,6 +34,10 @@ module PgHero
         connection.quote_column_name(value)
       end
 
+      def drop_idx_concurrently_supported?
+        server_version_num >= 140000
+      end
+
       private
 
       def select_all(sql, conn: nil, query_columns: [])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2161008/209854303-22a92c48-4a90-44ed-8ec6-55b400d4be27.png)

PostgreSQL DROP INDEX documentation (linked) says this:

> Drop the index without locking out concurrent selects, inserts,
updates, and deletes on the index's table

Background:
When duplicate indexes are detected, PgHero recommends removing one of them. To help make this possible, it provides some commands to generate a Rails Migration. The implementation performs a `remove_index`

PostgreSQL Background:
In PostgreSQL it's possible to remove an index using the CONCURRENTLY keyword. e.g. `DROP INDEX index_name CONCURRENTLY`

Concurrent modifications are supported by Active Record in the same way as `add_index` with `remove_index`, using the combo of `disable_ddl_transaction!` and `algorithm: :concurrently`.

(no longer optional)
~~This PR adds a new optional configuration parameter to control this behavior. When this parameter is disabled, there is no change to PgHero. It may make sense to disable this by default and allow users to opt in.~~

~~When this parameter is enabled (set to true), behavior changes slightly.~~ Additional text is added to the HTML view showing how to generate a `remove_column` migration using the Active Record equivalent which is `algorithm: :concurrently`.

Links to Rails docs on disabling DDL transactions (`disable_ddl_transaction!` in Active Record), and links to PostgreSQL `DROP INDEX` documentation are added.

Ideally, the new migration could be generated with `disable_ddl_transaction!` set already. Unfortunately it doesn't seem possible currently in Active Record to do this, so it was added to the explanation text area.