### PR TITLE
Group partitions together in Space view

### DIFF
--- a/app/assets/javascripts/pghero/application.js
+++ b/app/assets/javascripts/pghero/application.js
@@ -157,3 +157,26 @@ function initSlider() {
     refreshStats(false);
   });
 }
+
+$(() => {
+  $('[data-toggle]').each((i, elem) => {
+    const toggler = $(elem);
+    const togglerName = toggler.data('toggle');
+    const stateKeyName = 'toggler-state-' + togglerName;
+    const targets = $('[data-toggle-target=' + togglerName + ']');
+    const checked = localStorage.getItem(stateKeyName) == "true";
+    toggler.prop('checked', checked);
+
+    toggler.on('change', () => {
+      const checked = toggler.prop('checked');
+      localStorage.setItem(stateKeyName, checked.toString());
+      if(checked) {
+        targets.show();
+      } else {
+        targets.hide();
+      }
+    });
+
+    toggler.trigger('change');
+  })
+});

--- a/app/views/pg_hero/home/_space_row.html.erb
+++ b/app/views/pg_hero/home/_space_row.html.erb
@@ -1,0 +1,40 @@
+<% if (parent_oid = query[:parent_oid]) %>
+<tbody data-toggle-target='oid-<%= parent_oid %>' style="display:none">
+<% else %>
+<tbody>
+<% end %>
+  <tr>
+    <% if query[:partitions].any? %>
+      <td style="width: 1em"><input type=checkbox data-toggle="oid-<%= query[:oid] %>" class="show-partitions-toggle" /></td>
+    <% else %>
+      <td style="width: 0em"></td>
+    <% end %>
+
+    <td style="<%= query[:type] == "index" ? "font-style: italic;" : "" %>">
+      <span style="word-break: break-all;">
+        <% name = query[:relation] || query[:table] %>
+        <% if @space_stats_enabled %>
+          <%= link_to name, relation_space_path(name, schema: query[:schema]), target: "_blank", style: "color: inherit;" %>
+        <% else %>
+          <%= name %>
+        <% end %>
+      </span>
+      <% if query[:schema] != "public" %>
+        <span class="text-muted"><%= query[:schema] %></span>
+      <% end %>
+      <% if @unused_index_names.include?(query[:relation]) %>
+        <span class="unused-index">UNUSED</span>
+      <% end %>
+    </td>
+    <td><%= query[:size] %></td>
+    <% if @space_stats_enabled %>
+      <td>
+        <% if @growth_bytes_by_relation[[query[:schema], query[:relation]]] %>
+          <% if @growth_bytes_by_relation[[query[:schema], query[:relation]]] < 0 %>-<% end %><%= PgHero.pretty_size(@growth_bytes_by_relation[[query[:schema], query[:relation]]].abs) %>
+        <% else %>
+          <span class="text-muted">Unknown</span>
+        <% end %>
+      </td>
+    <% end %>
+  </tr>
+</tbody>

--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -40,9 +40,10 @@
   <% if @sizes_timeout %>
     <p>Breakdown not available (system catalog locked)</p>
   <% else %>
-    <table class="table space-table">
+    <table class="table space-table" style="table-layout: auto">
       <thead>
         <tr>
+          <th></th>
           <th><%= link_to (@only_tables ? "Table" : "Relation"), @header_options.merge(sort: "name") %></th>
           <th style="width: 15%;"><%= link_to "Size", @header_options %></th>
           <% if @space_stats_enabled %>
@@ -50,38 +51,12 @@
           <% end %>
         </tr>
       </thead>
-      <tbody>
-        <% @relation_sizes.each do |query| %>
-          <tr>
-            <td style="<%= query[:type] == "index" ? "font-style: italic;" : "" %>">
-              <span style="word-break: break-all;">
-                <% name = query[:relation] || query[:table] %>
-                <% if @space_stats_enabled %>
-                  <%= link_to name, relation_space_path(name, schema: query[:schema]), target: "_blank", style: "color: inherit;" %>
-                <% else %>
-                  <%= name %>
-                <% end %>
-              </span>
-              <% if query[:schema] != "public" %>
-                <span class="text-muted"><%= query[:schema] %></span>
-              <% end %>
-              <% if @unused_index_names.include?(query[:relation]) %>
-                <span class="unused-index">UNUSED</span>
-              <% end %>
-            </td>
-            <td><%= query[:size] %></td>
-            <% if @space_stats_enabled %>
-              <td>
-                <% if @growth_bytes_by_relation[[query[:schema], query[:relation]]] %>
-                  <% if @growth_bytes_by_relation[[query[:schema], query[:relation]]] < 0 %>-<% end %><%= PgHero.pretty_size(@growth_bytes_by_relation[[query[:schema], query[:relation]]].abs) %>
-                <% else %>
-                  <span class="text-muted">Unknown</span>
-                <% end %>
-              </td>
-            <% end %>
-          </tr>
+      <% @relation_sizes.reject { |row| row[:parent] }.each do |query| %>
+        <%= render partial: "space_row", locals: { query: query } %>
+        <% query[:partitions].each do |partition| %>
+          <%= render partial: "space_row", locals: { query: partition } %>
         <% end %>
-      </tbody>
+      <% end %>
     </table>
   <% end %>
 </div>


### PR DESCRIPTION
A quick attempt at https://github.com/ankane/pghero/issues/458 to collapse partitions, and show the total sum of the partitions on the parent table.

Whether a row is collapsed or not is sticky, stored in localStorage. Screenshots below:

By default, partitions are collapsed: 

<img width="807" alt="image" src="https://github.com/ankane/pghero/assets/1578600/e36ca1b2-d0cc-4101-84d7-14400faea90d">

And clicking the check-box expands them:
<img width="771" alt="image" src="https://github.com/ankane/pghero/assets/1578600/22743702-ac4e-4989-be70-005b687cbe3c">
