### PR TITLE
Fix Rails guide Devise routes typo

### DIFF
--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -38,7 +38,7 @@ ENV["PGHERO_PASSWORD"] = "hyrule"
 For Devise, use:
 
 ```ruby
-authenticate :user, -> (user) { user.admin? } do
+authenticated :user, -> (user) { user.admin? } do
   mount PgHero::Engine, at: "pghero"
 end
 ```


### PR DESCRIPTION
This fixes a small typo in the Rails guide regarding Devise restricted admin routes.