### PR TITLE
Show space usage for materialized views

### DIFF
--- a/lib/pghero/methods/space.rb
+++ b/lib/pghero/methods/space.rb
@@ -10,7 +10,7 @@ module PgHero
           SELECT
             n.nspname AS schema,
             c.relname AS relation,
-            CASE WHEN c.relkind = 'r' THEN 'table' ELSE 'index' END AS type,
+            CASE c.relkind WHEN 'r' THEN 'table' WHEN 'm' then 'matview' ELSE 'index' END AS type,
             pg_table_size(c.oid) AS size_bytes
           FROM
             pg_class c
@@ -19,7 +19,7 @@ module PgHero
           WHERE
             n.nspname NOT IN ('pg_catalog', 'information_schema')
             AND n.nspname !~ '^pg_toast'
-            AND c.relkind IN ('r', 'i')
+            AND c.relkind IN ('r', 'm', 'i')
           ORDER BY
             pg_table_size(c.oid) DESC,
             2 ASC

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
-  create_table :users, force: true do |t|
+  create_table :users, force: :cascade do |t|
     t.integer :city_id
     t.integer :login_attempts
     t.string :email

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,3 +72,4 @@ users =
   end
 User.insert_all!(users)
 ActiveRecord::Base.connection.execute("ANALYZE users")
+ActiveRecord::Base.connection.execute("CREATE MATERIALIZED VIEW all_users AS SELECT * FROM users")


### PR DESCRIPTION
Currently, the "Space" section contains space info only about tables and indexes, but not materialized views, even though that indexes for materialized views are already shown. This PR fixes that.

I have a few other improvement ideas to this gem:
1. Add some info about indexes on columns having a very high NULL fraction (`pg_stats.null_frac`), or indexes on columns with a high % of the same value (`pg_stats.most_common_freqs`), or indexes on boolean columns? These indexes should be made partial or removed.
2. Show also space occupied by partitioned tables.
3. Add to the "Space" section for tables a column showing its size with all its indexes. Or this can be a clickable link from the "Space" section for tables that show a new view with this info and some other details

Can help with PRs.  