### PR TITLE
Remove commented code that breaks better-html

### DIFF
--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -10,12 +10,6 @@
     </script>
   <% end %>
 
-  <!--
-  <% if @index_bloat.any? %>
-    <p>Check out <%= link_to "index bloat", index_bloat_path %> for an easy way to reclaim space.</p>
-  <% end %>
-  -->
-
   <% if @unused_indexes.any? %>
     <p>
       <%= pluralize(@unused_indexes.size, "unused index") %>. Remove them


### PR DESCRIPTION
Hi @ankane ,

I think that [better-html](https://github.com/Shopify/better-html) crashes with multiline ruby comments declared by `<!--`:

```
ActionView::Template::Error: Ruby statement not allowed

In 'comment' on line 14 column 0:
<%   if @index_bloat.any? 
^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

One way to solve this is to exclude external code from config : https://github.com/Shopify/better-html/issues/1#issuecomment-1811580644

```ruby
# config/initializers/better-html.rb

if defined?(BetterHtml)
  BetterHtml.configure do |config|
    config.template_exclusion_filter = proc { |filename|
      !filename.start_with?(Rails.root.to_s)
    }
  end
end
```

Another way is to remove this dead code from the view:

```diff
- <!--
- <% if @index_bloat.any? %>
-   <p>Check out <%= link_to "index bloat", index_bloat_path %> for an easy way to reclaim space.</p>
- <% end %>
- -->
```