### PR TITLE
Move time_zone setting outside of initializer

### DIFF
--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -73,7 +73,10 @@ module PgHero
     end
 
     def time_zone
-      @time_zone || Time.zone
+      @time_zone ||= begin
+        self.time_zone = (file_config || {})["time_zone"] || Time.zone
+        @time_zone
+      end
     end
 
     # use method instead of attr_accessor to ensure

--- a/lib/pghero/engine.rb
+++ b/lib/pghero/engine.rb
@@ -16,8 +16,6 @@ module PgHero
           app.config.assets.precompile << proc { |path| path == "pghero/favicon.png" }
         end
       end
-
-      PgHero.time_zone = PgHero.config["time_zone"] if PgHero.config["time_zone"]
     end
   end
 end


### PR DESCRIPTION
In the `pghero` initializer, we read the `PgHero.config` to check the `time_zone`. The `default_config` access some information via `ActiveRecord::Base`. This caused `ActiveRecord::Base` to be loaded too early (cf https://github.com/rails/rails/issues/50133), and in this case we can simply avoid accessing it during initialization by just moving where we set the `time_zone`.