### PR TITLE
[IDEA] feat: add copy button to visualize code area

### DIFF
--- a/app/assets/javascripts/pghero/application.js
+++ b/app/assets/javascripts/pghero/application.js
@@ -171,3 +171,18 @@ $(document).on("click", ".show-details", function () {
   $(this).nextAll(".details").css("display", "block");
   $(this).css("display", "none");
 });
+
+$(document).on("click", "#copy-explanation", function (e) {
+  e.preventDefault();
+  const button = $(this);
+  const explanation = button.closest(".explanation-container").find("pre code").text();
+
+  navigator.clipboard.writeText(explanation).then(function () {
+    button.text('Copied!');
+    setTimeout(function () {
+      button.text('Copy');
+    }, 2000);
+  }).catch(function (err) {
+    console.error('Could not copy text: ', err);
+  });
+});

--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -618,3 +618,13 @@ a.relation-link {
   color: #f0ad4e;
   background-color: #333;
 }
+
+.explanation-container {
+  position: relative;
+}
+
+#copy-explanation {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}

--- a/app/views/pg_hero/home/explain.html.erb
+++ b/app/views/pg_hero/home/explain.html.erb
@@ -16,7 +16,14 @@
     <% if @visualize %>
       <p>Paste the output below into the <%= link_to "explain visualizer", PgHero.visualize_url, target: "_blank" %></p>
     <% end %>
-    <pre><code><%= @explanation %></code></pre>
+    <div class="explanation-container">
+      <% if @visualize %>
+        <button id="copy-explanation" class="btn btn-info" aria-label="Copy explanation to clipboard" title="Copy to clipboard">
+          Copy
+        </button>
+      <% end %>
+      <pre><code><%= @explanation %></code></pre>
+    </div>
     <% unless @visualize %>
       <p><%= link_to "See how to interpret this", "https://www.postgresql.org/docs/current/static/using-explain.html", target: "_blank" %></p>
     <% end %>


### PR DESCRIPTION
When using EXPLAIN and the visualizer its a pain to have to manually copy out the JSON that gets generated, This PR adds a button to do that. 

![image](https://github.com/user-attachments/assets/e97267d7-d329-40da-aff5-814059f85e21)

I tried to keep the JavaScript and CSS to a minimum. 