### PR TITLE
Added query that enables stats extension to permissions docs

### DIFF
--- a/guides/Permissions.md
+++ b/guides/Permissions.md
@@ -22,6 +22,7 @@ $$
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
 -- query stats
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 CREATE OR REPLACE FUNCTION pghero.pg_stat_statements() RETURNS SETOF pg_stat_statements AS
 $$
   SELECT * FROM public.pg_stat_statements;


### PR DESCRIPTION
SQL views provided by the PostgreSQL extension `pg_stat_statements` are not enabled globally for all databases [1], so they need to be explicitly enabled when setting up a new database.

[1]: https://www.postgresql.org/docs/current/pgstatstatements.html

[skip ci]