### PR TITLE
 Add a config option to disable kill connections

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -9,6 +9,7 @@ module PgHero
     before_action :set_query_stats_enabled
     before_action :set_show_details, only: [:index, :queries, :show_query]
     before_action :ensure_query_stats, only: [:queries]
+    before_action :ensure_kill_connections_enabled, only: [:kill, :kill_long_running_queries, :kill_all]
 
     if PgHero.config["override_csp"]
       # note: this does not take into account asset hosts
@@ -462,6 +463,7 @@ module PgHero
       @system_stats_enabled = @database.system_stats_enabled?
       @replica = @database.replica?
       @explain_enabled = PgHero.explain_enabled?
+      @kill_connections_enabled = PgHero.kill_connections_enabled?
     end
 
     def set_suggested_indexes(min_average_time = 0, min_calls = 0)
@@ -522,6 +524,12 @@ module PgHero
     def ensure_query_stats
       unless @query_stats_enabled
         redirect_to root_path, alert: "Query stats not enabled"
+      end
+    end
+
+    def ensure_kill_connections_enabled
+      unless @kill_connections_enabled
+        render_text "Kill connections not enabled", status: :bad_request
       end
     end
 

--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -35,7 +35,9 @@
           <% unless @database.filter_data %>
             <%= button_to "Explain", explain_path, params: {query: query[:query]}, form: {target: "_blank"}, class: "btn btn-info" %>
           <% end %>
-          <%= button_to "Kill", kill_path(pid: query[:pid]), class: "btn btn-danger" %>
+          <% if @kill_connections_enabled %>
+            <%= button_to "Kill", kill_path(pid: query[:pid]), class: "btn btn-danger" %>
+          <% end %>
         </td>
       </tr>
       <tr>

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -190,7 +190,9 @@
 
 <% if @long_running_queries.any? %>
   <div class="content">
-    <%= button_to "Kill All", kill_long_running_queries_path, class: "btn btn-danger", style: "float: right;" %>
+    <% if @kill_connections_enabled %>
+      <%= button_to "Kill All", kill_long_running_queries_path, class: "btn btn-danger", style: "float: right;" %>
+    <% end %>
     <h1>Long Running Queries</h1>
 
     <p>We recommend setting a statement timeout on all non-superusers with:</p>

--- a/app/views/pg_hero/home/live_queries.html.erb
+++ b/app/views/pg_hero/home/live_queries.html.erb
@@ -5,7 +5,9 @@
 
   <%= render partial: "live_queries_table", locals: {queries: @running_queries, vacuum_progress: @vacuum_progress} %>
 
-  <p><%= button_to "Kill all connections", kill_all_path, class: "btn btn-danger" %></p>
+  <% if @kill_connections_enabled %>
+    <p><%= button_to "Kill all connections", kill_all_path, class: "btn btn-danger" %></p>
+  <% end %>
 
   <p class="text-muted">You may need to restart your app servers afterwards.</p>
 </div>

--- a/lib/generators/pghero/templates/config.yml.tt
+++ b/lib/generators/pghero/templates/config.yml.tt
@@ -50,3 +50,6 @@ databases:
 
 # Filter data from queries (experimental)
 # filter_data: true
+
+# Disable kill connection buttons (enabled by default)
+# kill_connections: false

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -99,8 +99,18 @@ module PgHero
     end
 
     # private
+    def kill_connections_enabled?
+      kill_connections.nil? || kill_connections == true
+    end
+
+    # private
     def explain_mode
       @config["explain"]
+    end
+
+    # private
+    def kill_connections
+      @config["kill_connections"]
     end
 
     def visualize_url

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -182,6 +182,49 @@ class ControllerTest < ActionDispatch::IntegrationTest
   #   assert_redirected_to "/"
   # end
 
+  def test_live_queries_kill_button
+    get pg_hero.live_queries_path
+    assert_response :success
+    assert_match "Kill all connections", response.body
+  end
+
+  def test_live_queries_kill_button_disabled
+    with_kill_connections(false) do
+      get pg_hero.live_queries_path
+    end
+    assert_response :success
+    refute_match "Kill all connections", response.body
+  end
+
+  def test_kill_all_not_enabled
+    with_kill_connections(false) do
+      post pg_hero.kill_all_path
+    end
+    assert_response :bad_request
+    assert_match "Kill connections not enabled", response.body
+  end
+
+  def test_kill_long_running_queries_not_enabled
+    with_kill_connections(false) do
+      post pg_hero.kill_long_running_queries_path
+    end
+    assert_response :bad_request
+    assert_match "Kill connections not enabled", response.body
+  end
+
+  def test_kill_not_enabled
+    with_kill_connections(false) do
+      post pg_hero.kill_path(pid: 1_000_000_000)
+    end
+    assert_response :bad_request
+    assert_match "Kill connections not enabled", response.body
+  end
+
+  def test_kill_long_running_queries_enabled_by_default
+    post pg_hero.kill_long_running_queries_path
+    assert_redirected_to "/"
+  end
+
   def test_reset_query_stats
     post pg_hero.reset_query_stats_path
     assert_redirected_to "/"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,13 @@ class Minitest::Test
     PgHero.remove_instance_variable(:@config)
   end
 
+  def with_kill_connections(value)
+    PgHero.config.merge!({"kill_connections" => value})
+    yield
+  ensure
+    PgHero.remove_instance_variable(:@config)
+  end
+
   def with_explain_timeout(value)
     previous_value = PgHero.explain_timeout_sec
     begin


### PR DESCRIPTION
PgHero lets anyone with access to the dashboard kill queries and drop connections. 
On shared or production databases we'd rather not have those buttons available at all, so this adds a `kill_connections` option to turn them off.

It's enabled by default, so nothing changes unless you opt out:

```yaml
# Disable kill connection buttons (enabled by default)
kill_connections: false
```

When disabled, the `Kill`, `Kill All`, and `Kill all connections` buttons disappear from the Overview and Live Queries pages. It also blocks the underlying endpoints server side, so the actions can't be triggered by posting to them directly. Hiding the buttons alone wasn't enough

I had this idea due to this issue https://github.com/ankane/pghero/issues/498