### PR TITLE
Treat unlogged sequences as unreadable on replicas

### DIFF
--- a/lib/pghero/methods/sequences.rb
+++ b/lib/pghero/methods/sequences.rb
@@ -93,7 +93,7 @@ module PgHero
           SELECT
             n.nspname AS schema,
             c.relname AS sequence,
-            has_sequence_privilege(c.oid, 'SELECT') AS readable
+            has_sequence_privilege(c.oid, 'SELECT') AND (c.relpersistence = 'p' OR NOT pg_is_in_recovery()) AS readable
           FROM
             pg_class c
           INNER JOIN


### PR DESCRIPTION
This is an edge case I found when connecting to a replica *and* using unlogged tables. Feel free to drop this PR if it's too edge casey!

So, to replicate this problem you can do this:

1. On the primary, create an unlogged table with a serial column:

`CREATE UNLOGGED TABLE my_scratch_table (id SERIAL PRIMARY KEY);`

1. On Postgres 15+, the serial column creates an unlogged sequence behind the scenes.
2. Point PgHero at a physical replica of that primary and open the dashboard (or call PgHero.sequences).
3. It fails with:

`PG::FeatureNotSupported: ERROR: cannot access temporary or unlogged relations during recovery`

*What's happening:* unlogged tables and sequences still show up in the system catalogs on the replica, but Postgres won't let you read them while the server is in recovery. PgHero only checks has_sequence_privilege before running SELECT last_value FROM ... on every sequence, so the unlogged sequence passes the check and then errors. And since the last_value queries are batched together with UNION ALL, one unlogged sequence breaks the whole overview/sequences page.

*The fix:* treat a sequence as unreadable when it's not permanent and the server is in recovery. Unreadable sequences are already handled gracefully (they're listed without a last_value), and primaries are unaffected because pg_is_in_recovery() is false there.
