### PR TITLE
Fix shell quoting in Ubuntu installation script

### DIFF
--- a/guides/Linux.md
+++ b/guides/Linux.md
@@ -10,7 +10,7 @@
 ```sh
 wget -qO- https://dl.packager.io/srv/pghero/pghero/key | sudo apt-key add -
 sudo wget -O /etc/apt/sources.list.d/pghero.list \
-  https://dl.packager.io/srv/pghero/pghero/master/installer/ubuntu/$(. /etc/os-release && echo $VERSION_ID).repo
+  "https://dl.packager.io/srv/pghero/pghero/master/installer/ubuntu/$(. /etc/os-release && echo $VERSION_ID).repo"
 sudo apt-get update
 sudo apt-get -y install pghero
 ```


### PR DESCRIPTION
## Problem
The installation script for Ubuntu has a shell parsing error due to improper quoting of the command substitution `$(. /etc/os-release && echo $VERSION_ID)` in the `wget` URL.

The current command fails with: zsh: parse error near `)'

## Solution
Wrap the URL in double quotes to allow proper shell expansion of the command substitution before passing it to `wget`.

**Before:**
```bash
wget -qO- https://dl.packager.io/srv/pghero/pghero/key | sudo apt-key add -
sudo wget -O /etc/apt/sources.list.d/pghero.list \
  https://dl.packager.io/srv/pghero/pghero/master/installer/ubuntu/$(. /etc/os-release && echo $VERSION_ID).repo
sudo apt-get update
sudo apt-get -y install pghero
```

**After:**
```bash
wget -qO- https://dl.packager.io/srv/pghero/pghero/key | sudo apt-key add -
sudo wget -O /etc/apt/sources.list.d/pghero.list \
  "https://dl.packager.io/srv/pghero/pghero/master/installer/ubuntu/$(. /etc/os-release && echo $VERSION_ID).repo"
sudo apt-get update
sudo apt-get -y install pghero
```

## Testing
- Tested on Ubuntu with bash and zsh shells
- Installation script now completes without parsing errors